### PR TITLE
chore(lts): add panel contract guard

### DIFF
--- a/.github/workflows/lts-panel-contract.yml
+++ b/.github/workflows/lts-panel-contract.yml
@@ -1,0 +1,36 @@
+name: LTS Panel Contract
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  lts-panel-contract:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check LTS panel contract
+        run: scripts/check-lts-panel-contract.sh
+
+      - name: Type-check
+        run: npm run type-check
+
+      - name: Build single-file panel
+        run: npm run build
+
+      - name: Lint
+        run: npm run lint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,8 @@ Confirmed upstream removal boundary:
 - `b25f722` starts switching provider usage tracking to recent requests.
 - `632be0b` removes the full usage UI, store, API client, and usage utilities at large scale.
 
+Panel maintenance mode is protected selective-port, not protected full-sync. `CPA-Core-LTS` can full-sync because its protected delta is small and localized; this Panel cannot, because upstream deletes the protected usage UI itself. Port compatible upstream fixes deliberately, and reject or adapt changes that weaken complete usage statistics.
+
 When following upstream:
 
 - Do not use GitHub `Sync fork` blindly.
@@ -104,6 +106,8 @@ When following upstream:
 - Before merging an upstream change, check whether it touches usage routes, usage store, usage API client, provider status bar, auth-file stats, quota display, or release workflow.
 - If an upstream change removes or weakens full statistics, preserve the LTS implementation first and port only unrelated compatible pieces.
 - Lightweight cleanup may remove promotional copy, sponsorship text, unused pages, unused providers, or non-target release machinery, but must not remove code still needed by the Core/Panel statistics contract.
+- Run `scripts/check-lts-panel-contract.sh` before opening or merging upstream-port PRs.
+- For detailed upstream handling rules, read `docs/lts/sync-runbook.md` and `docs/lts/panel-protected-deltas.yaml`.
 
 ## CPA-Core-LTS contract
 
@@ -132,6 +136,7 @@ All commands below are confirmed from `package.json`, `.github/workflows/release
 | `npm run lint` | Run ESLint on `ts,tsx` files | repo | Does not validate `scripts/*.js` userscripts |
 | `npm run type-check` | Run `tsc --noEmit` | repo | Good first validation for TypeScript-only changes |
 | `npm run format` | Run Prettier over `src/**/*.{ts,tsx,css,scss}` | `src/` only | Writes files; use only when formatting source changes is intended |
+| `scripts/check-lts-panel-contract.sh` | Check Panel LTS sentinel paths, release asset contract, and npm lockfile policy | repo | Lightweight guard; does not replace browser or Core compatibility smoke |
 
 There is no configured `npm test` script in this repository. Do not claim tests passed unless a real test command is added or provided by the user.
 
@@ -152,10 +157,11 @@ For TypeScript or UI changes:
 For usage statistics changes:
 
 1. Read `src/components/usage/AGENTS.md`.
-2. Run `npm run type-check`.
-3. Run `npm run build`.
-4. Inspect `src/router/MainRoutes.tsx`, `src/pages/UsagePage.tsx`, `src/services/api/usage.ts`, `src/stores/useUsageStatsStore.ts`, `src/types/usage.ts`, `src/utils/usage.ts`, and `src/utils/usageIndex.ts` for contract drift.
-5. If the change depends on Core behavior, verify against current `CPA-Core-LTS` Management API code or live endpoint; do not infer fields from memory.
+2. Run `scripts/check-lts-panel-contract.sh`.
+3. Run `npm run type-check`.
+4. Run `npm run build`.
+5. Inspect `src/router/MainRoutes.tsx`, `src/pages/UsagePage.tsx`, `src/services/api/usage.ts`, `src/stores/useUsageStatsStore.ts`, `src/types/usage.ts`, `src/utils/usage.ts`, and `src/utils/usageIndex.ts` for contract drift.
+6. If the change depends on Core behavior, verify against current `CPA-Core-LTS` Management API code or live endpoint; do not infer fields from memory.
 
 For release workflow changes:
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ Maintenance rules:
 - Keep compatibility with `CPA-Core-LTS` Management API usage endpoints.
 - Track upstream UI fixes selectively, but do not blindly sync upstream if the change removes or weakens full statistics.
 - Planned cleanup can remove promotional copy, unused UI surfaces, and non-LTS release machinery, but must not break the usage statistics contract.
+- Panel upstream handling uses protected selective-port, not Core-style protected full-sync, because upstream deletes the full usage UI itself.
+
+Maintenance references:
+
+- `docs/lts/sync-runbook.md`
+- `docs/lts/panel-protected-deltas.yaml`
+- `scripts/check-lts-panel-contract.sh`
 
 Since version 6.0.19, the Web UI ships with the main program; access it via `/management.html` on the API port once the service is running. `CPA-Core-LTS` downloads the latest release asset named `management.html` from this repository by default.
 
@@ -171,6 +178,7 @@ npm run preview    # serve dist locally
 npm run lint       # ESLint (fails on warnings)
 npm run format     # Prettier
 npm run type-check # tsc --noEmit
+scripts/check-lts-panel-contract.sh # LTS protected usage/release contract guard
 ```
 
 ## Contributing

--- a/README_CN.md
+++ b/README_CN.md
@@ -32,6 +32,13 @@ CPA Panel LTS 是 `CPA-Core-LTS` 的长期维护版 Web 管理面板。
 - 必须保持与 `CPA-Core-LTS` Management API usage endpoints 的兼容。
 - 可以选择性跟进上游 UI 修复，但不要盲目同步会移除或削弱完整统计能力的上游改动。
 - 后续轻量化改造可以移除推广文案、无用 UI、非 LTS 发布链路，但不能破坏使用统计契约。
+- Panel 的上游处理模式是 protected selective-port，不是 Core 那种 protected full-sync，因为 Panel upstream 直接删除了完整统计 UI 本身。
+
+维护参考：
+
+- `docs/lts/sync-runbook.md`
+- `docs/lts/panel-protected-deltas.yaml`
+- `scripts/check-lts-panel-contract.sh`
 
 从6.0.19版本开始，Web UI 随主程序一起提供；服务运行后，通过 API 端口上的"/management.html"访问它。`CPA-Core-LTS` 默认会从本仓库 latest release 下载名为 `management.html` 的资产。
 
@@ -170,6 +177,7 @@ npm run preview    # 本地预览 dist
 npm run lint       # ESLint（warnings 视为失败）
 npm run format     # Prettier
 npm run type-check # tsc --noEmit
+scripts/check-lts-panel-contract.sh # LTS 统计/发布契约检查
 ```
 
 ## 贡献

--- a/docs/lts/panel-protected-deltas.yaml
+++ b/docs/lts/panel-protected-deltas.yaml
@@ -1,0 +1,84 @@
+maintenance_model:
+  type: protected-selective-port
+  product_branch: main
+  upstream_source: router-for-me/Cli-Proxy-API-Management-Center main
+  paired_core: BlueSkyXN/CPA-Core-LTS main
+  release_asset: management.html
+
+protected_deltas:
+  - id: full-usage-statistics-ui
+    reason: CPA-Panel-LTS exists to preserve the full usage statistics UI after upstream moved toward recent requests and API-key summaries.
+    must_keep:
+      - /usage route
+      - UsagePage
+      - complete usage components
+      - usage API client
+      - usage Zustand store
+      - usage aggregation utilities
+      - import/export
+      - request events table
+      - model/API/credential breakdowns
+      - cached/reasoning token breakdown
+      - local model price settings
+  - id: cpa-core-lts-management-api-compatibility
+    reason: The panel is shipped as the management UI for CPA-Core-LTS.
+    must_keep:
+      - /v0/management/usage
+      - /v0/management/usage/export
+      - /v0/management/usage/import
+      - usage-statistics-enabled config visibility
+      - auth file/provider status surfaces backed by complete usage details
+  - id: panel-release-contract
+    reason: CPA-Core-LTS downloads the latest panel release asset by exact name.
+    must_keep:
+      - release asset named management.html
+      - npm/package-lock based build
+      - v*-tls-* release tag guard
+      - codex-quota-compass.user.js release asset unless deliberately removed by user-approved release scope
+  - id: local-downstream-customizations
+    reason: This repository contains downstream panel work that is not present upstream.
+    must_keep:
+      - CPA-Panel-LTS documentation and release links
+      - Codex quota helper/userscript assets
+      - Codex remote cloud connect environment UI unless intentionally replaced
+      - local i18n and panel compatibility fixes
+
+upstream_boundaries:
+  baseline_tag: v1.8.4
+  baseline_commit: 8ed837c3d734c3970a6d6799c557bb6a6753360d
+  known_full_usage_retained_tag: v1.9.3
+  removal_start_commits:
+    - b25f722
+    - 632be0b
+  unsafe_upstream_directions:
+    - replacing complete usage statistics with recent requests only
+    - replacing complete usage statistics with API-key summaries only
+    - deleting src/components/usage
+    - deleting src/pages/UsagePage.tsx
+    - deleting src/services/api/usage.ts
+    - deleting src/stores/useUsageStatsStore.ts
+    - deleting src/utils/usage.ts
+    - deleting src/utils/usageIndex.ts
+
+sentinel_markers:
+  paths:
+    - src/router/MainRoutes.tsx
+    - src/pages/UsagePage.tsx
+    - src/pages/UsagePage.module.scss
+    - src/components/usage/
+    - src/services/api/usage.ts
+    - src/stores/useUsageStatsStore.ts
+    - src/types/usage.ts
+    - src/utils/usage.ts
+    - src/utils/usageIndex.ts
+    - src/utils/usage/
+    - .github/workflows/release.yml
+  strings:
+    - /usage
+    - /usage/export
+    - /usage/import
+    - usage-statistics-enabled
+    - CPA-Core-LTS
+    - management.html
+    - v*-tls-*
+    - full-usage-statistics-ui

--- a/docs/lts/sync-runbook.md
+++ b/docs/lts/sync-runbook.md
@@ -1,0 +1,153 @@
+# CPA-Panel-LTS upstream handling runbook
+
+## Summary
+
+`CPA-Panel-LTS` should not use the same full-sync strategy as `CPA-Core-LTS`.
+
+Core can use protected full-sync because its protected usage delta is small and can be replayed at a few integration points. Panel is different: the upstream management UI moved away from complete usage statistics and directly deleted the LTS-protected usage page, store, API client, and utilities. A blind merge would remove the main reason this repository exists.
+
+The maintenance model for Panel is therefore:
+
+```text
+main = CPA-Panel-LTS product line
+     + full usage statistics UI
+     + CPA-Core-LTS Management API compatibility
+     + selected compatible upstream UI/fix improvements
+     + local downstream panel customizations
+```
+
+## Last audited state
+
+Checked on 2026-06-10:
+
+- `origin/main`: `bbfa08bdaefa389a5924dae15862cf23d8ad95d3`
+- `upstream/main`: `657e5a82cbed738e82bdcf4cd3778a8a40fade48`
+- merge-base: `8ed837c3d734c3970a6d6799c557bb6a6753360d`
+- `origin/main..upstream/main`: 89 commits
+- `upstream/main..origin/main`: 25 commits
+
+The upstream diff deletes or replaces protected LTS usage files, including:
+
+- `src/components/usage/`
+- `src/pages/UsagePage.tsx`
+- `src/pages/UsagePage.module.scss`
+- `src/services/api/usage.ts`
+- `src/stores/useUsageStatsStore.ts`
+- `src/types/usage.ts`
+- `src/utils/usage.ts`
+- `src/utils/usageIndex.ts`
+
+This confirms that upstream full-sync is unsafe for Panel.
+
+## Maintenance rules
+
+Use protected selective-port:
+
+1. Fetch upstream and inspect first.
+2. Classify upstream commits as safe-port, adapt-port, reject, or defer.
+3. Cherry-pick or manually port compatible changes into a Panel LTS branch.
+4. Preserve complete usage UI and CPA-Core-LTS API compatibility.
+5. Run the Panel LTS contract check, type-check, build, and lint before PR.
+6. Merge Panel maintenance PRs normally. Do not use GitHub Sync fork.
+
+Do not:
+
+- Use GitHub Sync fork.
+- Run a blind `git merge upstream/main`.
+- Run file-level checkout from upstream over `src/`.
+- Delete or weaken `/usage`, `src/components/usage/`, `usageApi`, `useUsageStatsStore`, or usage utilities.
+- Introduce `bun.lock`, `yarn.lock`, or `pnpm-lock.yaml`; this repository uses npm and `package-lock.json`.
+- Rename the release asset away from `management.html`.
+
+## Classification guide
+
+Safe-port candidates:
+
+- Form validation and browser autofill fixes.
+- UI bug fixes that do not touch usage contracts.
+- Provider UX improvements that can be adapted without deleting complete usage details.
+- Auth file display fixes that preserve LTS-specific Codex environment behavior.
+- Release workflow hardening that keeps `management.html` and `v*-tls-*`.
+- Dependency/tooling updates after `npm run type-check`, `npm run build`, and `npm run lint` pass.
+
+Adapt-port candidates:
+
+- Provider workbench refactors.
+- Status bar or provider stats changes.
+- Auth-file stats changes.
+- Config schema changes that overlap `usage-statistics-enabled`.
+- Quota page changes that share parsing, account identity, or provider metadata.
+
+Reject by default:
+
+- Replacing complete usage statistics with recent requests only.
+- Replacing complete usage statistics with API-key usage summaries only.
+- Removing usage charts, import/export, request events, token breakdown, or local model prices.
+- Removing CPA-Core-LTS release/download assumptions.
+
+Defer:
+
+- Large UI rewrites where the protected usage chain cannot be preserved quickly.
+- Package manager migration away from npm.
+- Release semantics changes that need Core-side confirmation.
+
+## Suggested workflow
+
+```bash
+cd /Users/sky/Github/CPA-Panel-LTS
+git fetch origin --prune
+git fetch upstream --prune
+
+git status --short --branch
+git log --oneline --first-parent origin/main..upstream/main
+git diff --name-status origin/main..upstream/main -- src
+```
+
+Create a branch:
+
+```bash
+git switch -c codex/panel-upstream-port-YYYYMMDD origin/main
+```
+
+For each candidate:
+
+```bash
+git show --stat --name-status <upstream-sha>
+git show -- <paths>
+```
+
+Then either cherry-pick, manually port, or reject. Prefer small PRs grouped by feature area, not by file-level overwrite.
+
+After changes:
+
+```bash
+scripts/check-lts-panel-contract.sh
+npm run type-check
+npm run build
+npm run lint
+```
+
+## PR body checklist
+
+Each Panel upstream-port PR should state:
+
+- upstream commit(s) considered
+- commits ported
+- commits rejected or deferred, with reason
+- usage UI contract impact
+- CPA-Core-LTS Management API compatibility impact
+- release asset impact
+- validation commands and results
+
+## Release note
+
+Publishing a Panel release is separate from porting code. A release is externally visible and affects what `CPA-Core-LTS` can download as `management.html`, so it should be done only when explicitly requested.
+
+When releasing:
+
+1. Run `scripts/check-lts-panel-contract.sh`.
+2. Run `npm run type-check`.
+3. Run `npm run build`.
+4. Run `npm run lint`.
+5. Push only the exact intended tag, for example `v1-tls-0.0.3`.
+6. Verify the GitHub release contains `management.html`.

--- a/scripts/check-lts-panel-contract.sh
+++ b/scripts/check-lts-panel-contract.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+failures=0
+
+fail() {
+  printf 'LTS panel contract violation: %s\n' "$1" >&2
+  failures=$((failures + 1))
+}
+
+require_path() {
+  local path="$1"
+  if [ ! -e "$path" ]; then
+    fail "missing path: $path"
+  fi
+}
+
+require_file_contains() {
+  local file="$1"
+  local pattern="$2"
+  if [ ! -f "$file" ]; then
+    fail "missing file: $file"
+    return
+  fi
+  if ! grep -Fq -- "$pattern" "$file"; then
+    fail "missing marker '$pattern' in $file"
+  fi
+}
+
+require_repo_contains() {
+  local pattern="$1"
+  if ! grep -R -F -q --exclude-dir=.git --exclude-dir=node_modules --exclude-dir=dist -- "$pattern" .; then
+    fail "missing repository marker: $pattern"
+  fi
+}
+
+for path in \
+  src/router/MainRoutes.tsx \
+  src/pages/UsagePage.tsx \
+  src/pages/UsagePage.module.scss \
+  src/components/usage \
+  src/components/usage/AGENTS.md \
+  src/services/api/usage.ts \
+  src/stores/useUsageStatsStore.ts \
+  src/types/usage.ts \
+  src/utils/usage.ts \
+  src/utils/usageIndex.ts \
+  src/utils/usage \
+  docs/lts/panel-protected-deltas.yaml \
+  docs/lts/sync-runbook.md \
+  .github/workflows/release.yml \
+  package-lock.json
+do
+  require_path "$path"
+done
+
+require_file_contains src/router/MainRoutes.tsx "path: '/usage'"
+require_file_contains src/router/MainRoutes.tsx "UsagePage"
+require_file_contains src/components/layout/MainLayout.tsx "path: '/usage'"
+require_file_contains src/services/api/usage.ts "'/usage'"
+require_file_contains src/services/api/usage.ts "'/usage/export'"
+require_file_contains src/services/api/usage.ts "'/usage/import'"
+require_file_contains src/stores/useUsageStatsStore.ts "usageApi.getUsage"
+require_file_contains src/utils/constants.ts "USAGE: '/usage'"
+require_file_contains src/services/api/config.ts "'/usage-statistics-enabled'"
+require_file_contains src/services/api/index.ts "export * from './usage'"
+require_file_contains .github/workflows/release.yml "management.html"
+require_file_contains .github/workflows/release.yml "v*-tls-*"
+require_file_contains docs/lts/panel-protected-deltas.yaml "full-usage-statistics-ui"
+require_file_contains docs/lts/panel-protected-deltas.yaml "cpa-core-lts-management-api-compatibility"
+require_file_contains docs/lts/panel-protected-deltas.yaml "panel-release-contract"
+require_file_contains docs/lts/sync-runbook.md "protected selective-port"
+
+require_repo_contains "CPA-Core-LTS"
+require_repo_contains "usage-statistics-enabled"
+require_repo_contains "management.html"
+
+for lockfile in bun.lock yarn.lock pnpm-lock.yaml; do
+  if [ -e "$lockfile" ]; then
+    fail "unexpected secondary package-manager lockfile: $lockfile"
+  fi
+done
+
+if [ "$failures" -ne 0 ]; then
+  printf 'LTS panel contract check failed with %s violation(s).\n' "$failures" >&2
+  exit 1
+fi
+
+printf 'LTS panel contract check passed.\n'


### PR DESCRIPTION
## 背景

`CPA-Panel-LTS` 和 `CPA-Core-LTS` 的 upstream 跟踪策略不能完全相同。Core 可以走 protected full-sync；Panel 不适合盲目 full-sync，因为当前 upstream 已经沿着 recent requests / API-key summaries 方向删除了完整 usage UI 链路，包括 `src/components/usage/`、`UsagePage`、`usageApi`、`useUsageStatsStore` 和 usage utilities。

本 PR 把 Panel 的维护模式明确为 protected selective-port：选择性吸收 upstream UI/fix/tooling 改动，但必须保留完整 usage statistics UI、CPA-Core-LTS Management API 兼容性和 release asset 合同。

## 改动

- 新增 `docs/lts/panel-protected-deltas.yaml`，记录 Panel 必须保护的 delta、已知 upstream 删除边界和 sentinel markers。
- 新增 `docs/lts/sync-runbook.md`，记录 Panel upstream port 的分类、拒绝/适配规则、验证命令和 PR body checklist。
- 新增 `scripts/check-lts-panel-contract.sh`，检查 `/usage` 路由、usage UI 链路、usage API、`usage-statistics-enabled`、`management.html` release asset 和 npm lockfile 策略。
- 新增 `.github/workflows/lts-panel-contract.yml`，在 PR/push 上运行 contract、type-check、build、lint。
- 更新 `AGENTS.md`、`README.md`、`README_CN.md`，明确 Panel 是 protected selective-port，不是 Core-style protected full-sync。

## 验证

- `scripts/check-lts-panel-contract.sh`
- `npm run type-check`
- `npm run build`
- `npm run lint`
- `git diff --check`

## 说明

本 PR 不改 `src/` 业务 UI，不发布 release，不打 tag，不合并 upstream 代码。后续如果要跟进 upstream 的 89 个 commits，应按 runbook 逐项分类后小 PR port。
