### PR TITLE
refactor(lts): isolate codex details styles into the sidecar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ skills
 # Editor directories and files
 settings.local.json
 .codex
+.playwright-mcp/
 .vscode/*
 !.vscode/extensions.json
 .idea

--- a/docs/lts/panel-feature-contracts.yaml
+++ b/docs/lts/panel-feature-contracts.yaml
@@ -371,4 +371,7 @@ features:
       - cli-chat-proxy.grok.com/v1/billing
       - weekly_estimate_usd_inline
       - analytics_backend_now
+      - formatCodexUsdAmount
+      - .codexDetails[open] .codexDetailsChevron
+      - Est weekly 0.31 USD
       - credits_unit

--- a/scripts/check-lts-panel-contract.sh
+++ b/scripts/check-lts-panel-contract.sh
@@ -30,6 +30,18 @@ require_file_contains() {
   fi
 }
 
+require_file_not_contains() {
+  local file="$1"
+  local pattern="$2"
+  if [ ! -f "$file" ]; then
+    fail "missing file: $file"
+    return
+  fi
+  if grep -Fq -- "$pattern" "$file"; then
+    fail "unexpected marker '$pattern' in $file"
+  fi
+}
+
 require_repo_contains() {
   local pattern="$1"
   if ! grep -R -F -q --exclude-dir=.git --exclude-dir=node_modules --exclude-dir=dist --exclude-dir=local -- "$pattern" .; then
@@ -247,6 +259,13 @@ require_file_contains src/lts/codexQuota/config.ts "resetCodexQuota"
 require_file_contains src/lts/codexQuota/config.ts "CODEX_RATE_LIMIT_RESET_CREDITS_CONSUME_URL"
 require_file_contains src/lts/codexQuota/config.ts "weekly_estimate_usd_inline"
 require_file_contains src/lts/codexQuota/config.ts "analytics_backend_now"
+require_file_contains src/lts/codexQuota/config.ts "formatCodexUsdAmount"
+require_file_contains src/lts/codexQuota/styles.module.scss ".codexDetails[open] .codexDetailsChevron"
+require_file_contains src/pages/QuotaPage.module.scss ".codexDetailsSurface"
+require_file_contains src/pages/AuthFilesPage.module.scss ".codexDetailsSurface"
+require_file_not_contains src/pages/QuotaPage.module.scss ".codexDetailsSummary"
+require_file_not_contains src/pages/AuthFilesPage.module.scss ".codexDetailsSummary"
+require_file_contains scripts/smoke-lts-panel.py "Est weekly 0.31 USD"
 require_file_contains src/lts/i18n/en.lts.json "weekly_estimate_usd_inline"
 require_file_contains src/lts/i18n/zh-CN.lts.json "weekly_estimate_usd_inline"
 require_file_contains src/lts/i18n/zh-TW.lts.json "weekly_estimate_usd_inline"

--- a/scripts/smoke-lts-panel.py
+++ b/scripts/smoke-lts-panel.py
@@ -1181,6 +1181,7 @@ def run_quota_runtime_smoke(page: Any, app_url: str) -> None:
     codex_card.get_by_text("Plus", exact=True).wait_for()
     codex_card.get_by_text("Manual resets", exact=False).wait_for()
     codex_card.get_by_text("2", exact=True).first.wait_for()
+    codex_card.get_by_text("Est weekly 0.31 USD", exact=True).wait_for()
 
     # codexDetails analytics fold-out is LTS-isolated: its structure and the compound
     # `.codexDetails[open] .codexDetailsChevron` selector live in the codexQuota sidecar

--- a/scripts/smoke-lts-panel.py
+++ b/scripts/smoke-lts-panel.py
@@ -1182,6 +1182,16 @@ def run_quota_runtime_smoke(page: Any, app_url: str) -> None:
     codex_card.get_by_text("Manual resets", exact=False).wait_for()
     codex_card.get_by_text("2", exact=True).first.wait_for()
 
+    # codexDetails analytics fold-out is LTS-isolated: its structure and the compound
+    # `.codexDetails[open] .codexDetailsChevron` selector live in the codexQuota sidecar
+    # module, while each page injects only the .codexDetailsSurface background. Verify the
+    # fold-out renders (summary) and expands (details[open] + body), guarding the isolation.
+    usage_details = codex_card.get_by_text("Usage details", exact=True)
+    usage_details.wait_for()
+    usage_details.click()
+    codex_card.locator("details[open]").first.wait_for()
+    codex_card.get_by_text("Deep Usage", exact=False).first.wait_for()
+
     codex_card.get_by_role("button", name="Reset quota").click()
     confirm = page.get_by_role("dialog", name="Reset Codex quota")
     confirm.get_by_text("codex-smoke.json", exact=False).wait_for()

--- a/src/lts/codexQuota/config.ts
+++ b/src/lts/codexQuota/config.ts
@@ -1174,7 +1174,8 @@ const renderCodexItems = (
   helpers: QuotaRenderHelpers
 ): ReactNode => {
   // Codex quota CONTENT classes are LTS-owned (./styles.module.scss); the page-injected
-  // helpers still supply shared/layout classes (codexDetails*, premiumPlanValue, quotaRow…).
+  // helpers still supply shared/layout classes (premiumPlanValue, quotaRow…) plus the
+  // per-context .codexDetailsSurface background — codexDetails structure is sidecar-owned.
   const { styles: pageStyles, QuotaProgressBar } = helpers;
   const styleMap = { ...pageStyles, ...codexQuotaStyles };
   const { createElement: h, Fragment } = React;
@@ -1506,7 +1507,12 @@ const renderCodexItems = (
     nodes.push(
       h(
         'details',
-        { key: 'analytics-details', className: styleMap.codexDetails },
+        {
+          key: 'analytics-details',
+          className: [styleMap.codexDetails, styleMap.codexDetailsSurface]
+            .filter(Boolean)
+            .join(' '),
+        },
         h(
           'summary',
           { className: styleMap.codexDetailsSummary },

--- a/src/lts/codexQuota/config.ts
+++ b/src/lts/codexQuota/config.ts
@@ -1152,13 +1152,19 @@ const PREMIUM_CODEX_PLAN_TYPES = new Set(['pro', 'prolite', 'pro-lite', 'pro_lit
 const CODEX_STANDARD_NUMBER_FORMATTER = new Intl.NumberFormat(undefined, {
   maximumFractionDigits: 2,
 });
+const CODEX_USD_NUMBER_FORMATTER = new Intl.NumberFormat(undefined, {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
 
 const formatCodexPlainIntegerNumber = (value: number): string => String(Math.round(value));
 
 const formatCodexStandardNumber = (value: number): string =>
   CODEX_STANDARD_NUMBER_FORMATTER.format(value);
 
-const formatCodexUsd = (value: number): string => `$${value.toFixed(2)}`;
+const formatCodexUsdAmount = (value: number): string => CODEX_USD_NUMBER_FORMATTER.format(value);
+
+const formatCodexUsd = (value: number): string => `$${formatCodexUsdAmount(value)}`;
 
 const formatCodexAnalyticsDateRange = (range: CodexAnalyticsRange): string => {
   const endMs = Date.parse(`${range.endDateExclusive}T00:00:00Z`);
@@ -1215,7 +1221,7 @@ const renderCodexItems = (
     : null;
   const weeklyUsdInlineEstimate = weeklyEstimate
     ? t('codex_quota.weekly_estimate_usd_inline', {
-        usd: formatCodexPlainIntegerNumber(weeklyEstimate.totalUsdWithResetDay),
+        usd: formatCodexUsdAmount(weeklyEstimate.totalUsdWithResetDay),
       })
     : null;
   const weeklyInlineEstimateTitle = weeklyEstimate

--- a/src/lts/codexQuota/styles.module.scss
+++ b/src/lts/codexQuota/styles.module.scss
@@ -1,7 +1,8 @@
 // Codex quota — LTS-owned content styles (shared by quota page + auth-file card).
 // Extracted from QuotaPage/AuthFilesPage module (identical copies) to de-duplicate
-// and isolate. Context-specific layout (codexCard/codexControl(s)/codexGrid/
-// codexDetails*) intentionally stays in each page module.
+// and isolate. Context-specific layout (codexCard/codexControl(s)/codexGrid)
+// intentionally stays in each page module. The codexDetails family now lives here
+// too — only its surface background is injected per page via .codexDetailsSurface.
 @use '../../styles/variables' as *;
 @use '../../styles/mixins' as *;
 
@@ -165,4 +166,60 @@
 .codexMetricValueStrong {
   font-weight: 700;
   color: var(--text-primary);
+}
+
+// Collapsible analytics details. Structure is LTS-owned so the compound
+// .codexDetails[open] .codexDetailsChevron selector stays inside one CSS module
+// (a cross-module compound would not match the hashed classnames). Each page
+// injects only the surface background via .codexDetailsSurface.
+.codexDetails {
+  margin-top: $spacing-xs;
+  border: 1px solid var(--border-color);
+  border-radius: $radius-md;
+}
+
+.codexDetailsSummary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: $spacing-sm;
+  padding: $spacing-xs $spacing-sm;
+  cursor: pointer;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.codexDetailsSummaryMain {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.codexDetailsIcon {
+  display: inline-flex;
+  color: var(--text-tertiary);
+}
+
+.codexDetailsTitle {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.codexDetailsHint {
+  color: var(--text-tertiary);
+  font-size: 11px;
+}
+
+.codexDetailsChevron {
+  color: var(--text-tertiary);
+  transition: transform $transition-fast;
+}
+
+.codexDetails[open] .codexDetailsChevron {
+  transform: rotate(180deg);
+}
+
+.codexDetailsBody {
+  padding: 0 $spacing-sm $spacing-sm;
 }

--- a/src/pages/AuthFilesPage.module.scss
+++ b/src/pages/AuthFilesPage.module.scss
@@ -697,57 +697,10 @@
   color: #ffd862;
 }
 
-.codexDetails {
-  margin-top: $spacing-xs;
-  border: 1px solid var(--border-color);
-  border-radius: $radius-md;
+// codexDetails structure is LTS-owned (src/lts/codexQuota/styles.module.scss);
+// this page injects only the surface background for the auth-file-card context.
+.codexDetailsSurface {
   background: color-mix(in srgb, var(--bg-secondary) 86%, transparent);
-}
-
-.codexDetailsSummary {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: $spacing-sm;
-  padding: $spacing-xs $spacing-sm;
-  cursor: pointer;
-  color: var(--text-secondary);
-  font-size: 12px;
-}
-
-.codexDetailsSummaryMain {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  min-width: 0;
-}
-
-.codexDetailsIcon {
-  display: inline-flex;
-  color: var(--text-tertiary);
-}
-
-.codexDetailsTitle {
-  color: var(--text-primary);
-  font-weight: 600;
-}
-
-.codexDetailsHint {
-  color: var(--text-tertiary);
-  font-size: 11px;
-}
-
-.codexDetailsChevron {
-  color: var(--text-tertiary);
-  transition: transform $transition-fast;
-}
-
-.codexDetails[open] .codexDetailsChevron {
-  transform: rotate(180deg);
-}
-
-.codexDetailsBody {
-  padding: 0 $spacing-sm $spacing-sm;
 }
 
 // 单个认证文件卡片

--- a/src/pages/QuotaPage.module.scss
+++ b/src/pages/QuotaPage.module.scss
@@ -591,57 +591,10 @@
   }
 }
 
-.codexDetails {
-  margin-top: $spacing-xs;
-  border: 1px solid var(--border-color);
-  border-radius: $radius-md;
+// codexDetails structure is LTS-owned (src/lts/codexQuota/styles.module.scss);
+// this page injects only the surface background for the quota-page context.
+.codexDetailsSurface {
   background: var(--bg-secondary);
-}
-
-.codexDetailsSummary {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: $spacing-sm;
-  padding: $spacing-xs $spacing-sm;
-  cursor: pointer;
-  color: var(--text-secondary);
-  font-size: 12px;
-}
-
-.codexDetailsSummaryMain {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  min-width: 0;
-}
-
-.codexDetailsIcon {
-  display: inline-flex;
-  color: var(--text-tertiary);
-}
-
-.codexDetailsTitle {
-  color: var(--text-primary);
-  font-weight: 600;
-}
-
-.codexDetailsHint {
-  color: var(--text-tertiary);
-  font-size: 11px;
-}
-
-.codexDetailsChevron {
-  color: var(--text-tertiary);
-  transition: transform $transition-fast;
-}
-
-.codexDetails[open] .codexDetailsChevron {
-  transform: rotate(180deg);
-}
-
-.codexDetailsBody {
-  padding: 0 $spacing-sm $spacing-sm;
 }
 
 @include mobile {


### PR DESCRIPTION
## 目标
继续 LTS Codex 隔离收尾：把仍重复在两个上游页面 module 里的 `codexDetails` 折叠框样式整体迁入 LTS sidecar，缩小后续 upstream selective-port 的冲突面，并修正检查中发现的 Codex 周限美元预估显示问题。

## 改动
- 将 `codexDetails` 折叠框结构样式迁入 `src/lts/codexQuota/styles.module.scss`。
- 页面 module 只保留轻量 `.codexDetailsSurface`，分别注入 quota page 与 auth-file card 的背景差异。
- `src/lts/codexQuota/config.ts` 同时组合 sidecar 结构类与页面 surface 类，避免 CSS module compound selector 跨 module 后 hash 不匹配。
- 修正 Codex 周限美元预估格式化：`weekly_estimate_usd_inline` 现在保留两位小数，避免 `$0.31` 被显示成 `0 USD`。
- 忽略 Browser MCP 本地运行产物 `.playwright-mcp/`，避免真实页面检查污染 worktree。
- 扩展 `smoke:lts`：验证 “Usage details” 可展开，并断言 mock Codex 周限美元显示为 `Est weekly 0.31 USD`。
- 加强 `check:lts` / feature contract：CI 现在会守住 `codexDetails` compound selector 留在 sidecar、两个页面只保留 `.codexDetailsSurface`、以及美元小数 smoke marker。

## 为什么这样做
`codexDetails[open] .codexDetailsChevron` 这类 compound selector 必须让父子 class 同处一个 CSS module，否则 class hash 对不上，展开 chevron 状态可能失效。把结构放入 sidecar 后，upstream 页面样式更新时只剩 surface/background 级别的接线差异。

美元格式问题来自把 `totalUsdWithResetDay` 复用了整数 formatter。该字段本身已按两位小数计算，展示层应保留小数，否则低金额估算会被误导性地显示为 `0 USD`。

## 维护性判断
这次不是把逻辑拆得更散，而是把已经存在的 LTS-owned Codex quota 细节继续收束到 `src/lts/codexQuota/`。共享页面只留下上下文 surface 类，长期同步时更容易看出哪些是 upstream 页面布局，哪些是 LTS Codex 定制。

## 验证
- `git diff --check`
- `npm run check:lts`
- `npm run validate:lts`
  - `check:lts`
  - `type-check`
  - `lint`
  - `build`
- `npm run smoke:lts`

## 验证边界
- 本地 smoke 使用 mock Core API，覆盖 quota runtime、usage details fold-out、remote cloud connect runtime 等主要 LTS 路径。
- HF 线上 `management.html` 当前仍是旧部署，不包含本 PR 的最新 sidecar/remote cloud connect 标记；线上真实页面需要等最新构建部署后再复查。
