### PR TITLE
fix(usage): 修正 GPT-5.6 cache-write 定价与模型识别边界

### DIFF
--- a/.github/workflows/lts-panel-contract.yml
+++ b/.github/workflows/lts-panel-contract.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Test usage cache semantics
+        run: npm run test:usage-cache
+
       - name: Check LTS panel contract
         run: npm run check:lts
 

--- a/docs/lts/panel-feature-contracts.yaml
+++ b/docs/lts/panel-feature-contracts.yaml
@@ -30,6 +30,7 @@ features:
       - src/utils/usage.ts
       - src/utils/usageIndex.ts
       - src/utils/usage/
+      - src/utils/usage/cacheTokens.test.mjs
     core_endpoints:
       - /v0/management/usage
       - /v0/management/usage/export
@@ -41,9 +42,12 @@ features:
       - usageApi.importUsage
       - calculateStatusBarData
       - collectUsageDetailsForCandidates
+      - resolveUsageTotalTokens
+      - resolveCacheWriteUnitPrice
       - service_tier
       - request_events_filter_tier
     validation:
+      - npm run test:usage-cache
       - npm run check:lts
       - npm run check:feature-contract
       - npm run type-check
@@ -161,6 +165,10 @@ features:
       - x-lts-model-note
       - dropped provider unknown fields
       - dropped model unknown field
+      - dropped configured branded provider
+      - include_branded_providers
+      - run_branded_provider_visibility_smoke
+      - shown as a recommendation
       - run_browser_provider_workbench_smoke
       - run_browser_provider_key_crud_smoke
       - BROWSER provider workbench OpenAI Compatibility save PUT /v0/management/openai-compatibility

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:usage-cache": "node --test src/utils/usage/cacheTokens.test.mjs",
     "check:feature-contract": "node scripts/check-panel-feature-contracts.mjs",
     "check:lts": "scripts/check-lts-panel-contract.sh",
-    "validate:lts": "npm run check:lts && npm run type-check && npm run lint && npm run build",
+    "validate:lts": "npm run test:usage-cache && npm run check:lts && npm run type-check && npm run lint && npm run build",
     "smoke:lts": "npm run build && python3 scripts/smoke-lts-panel.py",
     "smoke:lts:core": "npm run build && python3 scripts/smoke-lts-panel-core.py"
   },

--- a/scripts/check-lts-panel-contract.sh
+++ b/scripts/check-lts-panel-contract.sh
@@ -138,6 +138,7 @@ for path in \
   src/utils/usage.ts \
   src/utils/usageIndex.ts \
   src/utils/usage \
+  src/utils/usage/cacheTokens.test.mjs \
   src/utils/recentRequests.ts \
   src/utils/quota \
   src/utils/constants.ts \
@@ -147,6 +148,7 @@ for path in \
   scripts/check-panel-feature-contracts.mjs \
   scripts/smoke-lts-panel.py \
   scripts/smoke-lts-panel-core.py \
+  .github/workflows/lts-panel-contract.yml \
   src/i18n/locales/en.json \
   src/i18n/locales/zh-CN.json \
   src/i18n/locales/zh-TW.json \
@@ -174,6 +176,9 @@ require_file_contains src/stores/useUsageStatsStore.ts "usageApi.getUsage"
 require_file_contains src/services/api/config.ts "'/usage-statistics-enabled'"
 require_file_contains src/utils/constants.ts "USAGE: '/usage'"
 require_file_contains src/utils/usage.ts "service_tier"
+require_file_contains src/utils/usage.ts "resolveUsageTotalTokens"
+require_file_contains src/utils/usage/cacheTokens.ts "resolveCacheWriteUnitPrice"
+require_file_contains src/utils/usage/cacheTokens.test.mjs "only explicit GPT-5.6 model slugs"
 require_file_contains src/components/usage/RequestEventsDetailsCard.tsx "service_tier"
 require_file_contains src/components/usage/RequestEventsDetailsCard.tsx "request_events_filter_tier"
 require_file_contains src/i18n/locales/en.json "request_events_filter_tier"
@@ -192,6 +197,7 @@ require_file_contains docs/lts/panel-protected-deltas.yaml "full-usage-statistic
 require_file_contains docs/lts/panel-protected-deltas.yaml "cpa-core-lts-management-api-compatibility"
 require_file_contains docs/lts/panel-protected-deltas.yaml "panel-release-contract"
 require_file_contains docs/lts/sync-runbook.md "protected selective-port"
+require_file_contains docs/lts/panel-feature-contracts.yaml "npm run test:usage-cache"
 
 # Accepted upstream feature regression checks.
 require_file_contains src/router/MainRoutes.tsx "path: '/ai-providers/workbench'"
@@ -617,6 +623,10 @@ require_file_contains scripts/smoke-lts-panel.py "x-lts-entry-note"
 require_file_contains scripts/smoke-lts-panel.py "x-lts-model-note"
 require_file_contains scripts/smoke-lts-panel.py "dropped provider unknown fields"
 require_file_contains scripts/smoke-lts-panel.py "dropped model unknown field"
+require_file_contains scripts/smoke-lts-panel.py "dropped configured branded provider"
+require_file_contains scripts/smoke-lts-panel.py "include_branded_providers"
+require_file_contains scripts/smoke-lts-panel.py "run_branded_provider_visibility_smoke"
+require_file_contains scripts/smoke-lts-panel.py "shown as a recommendation"
 require_file_contains scripts/smoke-lts-panel.py "OpenAI Compatibility PUT payload must not write response-only auth-index"
 require_file_contains scripts/smoke-lts-panel.py "openrouter-a"
 require_file_contains scripts/smoke-lts-panel.py "openrouter-b"
@@ -626,6 +636,9 @@ require_file_contains scripts/smoke-lts-panel.py "openai/smoke-discovered"
 require_file_contains scripts/smoke-lts-panel-core.py "Provider write smoke persisted response-only auth-index"
 
 # Smoke coverage markers.
+require_file_contains package.json "\"test:usage-cache\""
+require_file_contains package.json "\"validate:lts\": \"npm run test:usage-cache"
+require_file_contains .github/workflows/lts-panel-contract.yml "npm run test:usage-cache"
 require_file_contains package.json "\"smoke:lts\""
 require_file_contains package.json "\"smoke:lts:core\""
 require_file_contains scripts/check-panel-feature-contracts.mjs "panel-feature-contracts.yaml"

--- a/scripts/smoke-lts-panel.py
+++ b/scripts/smoke-lts-panel.py
@@ -72,6 +72,7 @@ class MockCoreState:
         self.config_yaml = build_config_yaml()
         self.config_yaml_puts: list[str] = []
         self.runtime_kind = "cpa"
+        self.include_branded_providers = True
 
     def record(self, method: str, path: str, query: str = "") -> None:
         suffix = f"?{query}" if query else ""
@@ -93,7 +94,71 @@ def build_recent_buckets() -> list[dict[str, Any]]:
     ]
 
 
-def build_config_payload() -> dict[str, Any]:
+def build_config_payload(include_branded_providers: bool = True) -> dict[str, Any]:
+    claude_api_keys = [
+        {
+            "api-key": "claude-key-1",
+            "base-url": "https://api.anthropic.com",
+            "models": [{"name": "claude-sonnet-4"}],
+        }
+    ]
+    openai_compatibility = [
+        {
+            "name": "OpenRouter",
+            "base-url": "https://openrouter.ai/api/v1",
+            "x-lts-unknown-provider": {"preserve": "provider"},
+            "api-key-entries": [
+                {
+                    "api-key": "openai-key-1",
+                    "auth-index": "openrouter-a",
+                    "x-lts-entry-note": "keep-entry-a",
+                },
+                {
+                    "api-key": "openai-key-2",
+                    "auth-index": "openrouter-b",
+                    "proxy-url": "http://127.0.0.1:7890",
+                    "x-lts-entry-note": "keep-entry-b",
+                },
+            ],
+            "models": [
+                {
+                    "name": "openai/mock-model",
+                    "alias": "mock-model",
+                    "test-model": "mock-model",
+                    "x-lts-model-note": "keep-model",
+                }
+            ],
+        }
+    ]
+
+    if include_branded_providers:
+        claude_api_keys.append(
+            {
+                "api-key": "claudeapi-smoke-key",
+                "base-url": "https://gw.claudeapi.com",
+                "models": [{"name": "claude-sonnet-4"}],
+            }
+        )
+        openai_compatibility.extend(
+            [
+                {
+                    "name": "code0",
+                    "base-url": "https://code0.ai/v1",
+                    "api-key-entries": [{"api-key": "code0-smoke-key"}],
+                },
+                {
+                    "name": "fennoAI",
+                    "base-url": "https://api.fenno.ai/v1",
+                    "api-key-entries": [{"api-key": "fenno-smoke-key"}],
+                },
+                {
+                    "name": "qiniuCloud",
+                    "base-url": "https://api.qnaigc.com/v1",
+                    "api-key-entries": [{"api-key": "qiniu-smoke-key"}],
+                },
+            ]
+        )
+
     return {
         "debug": False,
         "usage-statistics-enabled": True,
@@ -117,13 +182,7 @@ def build_config_payload() -> dict[str, Any]:
                 "models": [{"name": "gpt-5"}],
             }
         ],
-        "claude-api-key": [
-            {
-                "api-key": "claude-key-1",
-                "base-url": "https://api.anthropic.com",
-                "models": [{"name": "claude-sonnet-4"}],
-            }
-        ],
+        "claude-api-key": claude_api_keys,
         "vertex-api-key": [
             {
                 "api-key": "vertex-key-1",
@@ -131,34 +190,7 @@ def build_config_payload() -> dict[str, Any]:
                 "models": [{"name": "vertex-model", "alias": "vertex-alias"}],
             }
         ],
-        "openai-compatibility": [
-            {
-                "name": "OpenRouter",
-                "base-url": "https://openrouter.ai/api/v1",
-                "x-lts-unknown-provider": {"preserve": "provider"},
-                "api-key-entries": [
-                    {
-                        "api-key": "openai-key-1",
-                        "auth-index": "openrouter-a",
-                        "x-lts-entry-note": "keep-entry-a",
-                    },
-                    {
-                        "api-key": "openai-key-2",
-                        "auth-index": "openrouter-b",
-                        "proxy-url": "http://127.0.0.1:7890",
-                        "x-lts-entry-note": "keep-entry-b",
-                    },
-                ],
-                "models": [
-                    {
-                        "name": "openai/mock-model",
-                        "alias": "mock-model",
-                        "test-model": "mock-model",
-                        "x-lts-model-note": "keep-model",
-                    }
-                ],
-            }
-        ],
+        "openai-compatibility": openai_compatibility,
         "ampcode": {
             "upstream-url": "https://amp.example.test",
             "upstream-api-key": "sk-amp-smoke",
@@ -678,25 +710,28 @@ class MockCoreHandler(BaseHTTPRequestHandler):
         parsed = urlparse(self.path)
         path = parsed.path
         self.state.record("GET", path, parsed.query)
+        config_payload = build_config_payload(
+            include_branded_providers=self.state.include_branded_providers
+        )
 
         routes: dict[str, Any] = {
-            "/v0/management/config": build_config_payload(),
+            "/v0/management/config": config_payload,
             "/v0/management/auth-files": build_auth_files_payload(),
             "/v0/management/usage": build_usage_payload(),
             "/v0/management/usage/export": {"version": 1, "usage": build_usage_payload()["usage"]},
             "/v0/management/api-key-usage": build_api_key_usage_payload(),
-            "/v0/management/ampcode": {"ampcode": build_config_payload()["ampcode"]},
+            "/v0/management/ampcode": {"ampcode": config_payload["ampcode"]},
             "/v0/management/vertex-api-key": {
-                "vertex-api-key": build_config_payload()["vertex-api-key"]
+                "vertex-api-key": config_payload["vertex-api-key"]
             },
             "/v0/management/openai-compatibility": {
-                "openai-compatibility": build_config_payload()["openai-compatibility"]
+                "openai-compatibility": config_payload["openai-compatibility"]
             },
             "/v0/management/ampcode/upstream-api-keys": {
-                "upstream-api-keys": build_config_payload()["ampcode"]["upstream-api-keys"]
+                "upstream-api-keys": config_payload["ampcode"]["upstream-api-keys"]
             },
             "/v0/management/ampcode/model-mappings": {
-                "model-mappings": build_config_payload()["ampcode"]["model-mappings"]
+                "model-mappings": config_payload["ampcode"]["model-mappings"]
             },
             "/v0/management/oauth-excluded-models": {
                 "oauth-excluded-models": {"codex": ["gpt-5-disabled"]}
@@ -1212,6 +1247,36 @@ def assert_provider_mutation_payloads(state: MockCoreState) -> None:
                 "OpenAI Compatibility PUT payload dropped model unknown field: "
                 f"{payload!r}"
             )
+        for provider_name, base_url, api_key in [
+            ("code0", "https://code0.ai/v1", "code0-smoke-key"),
+            ("fennoAI", "https://api.fenno.ai/v1", "fenno-smoke-key"),
+            ("qiniuCloud", "https://api.qnaigc.com/v1", "qiniu-smoke-key"),
+        ]:
+            branded_provider = next(
+                (
+                    item
+                    for item in payload
+                    if isinstance(item, dict) and item.get("name") == provider_name
+                ),
+                None,
+            )
+            branded_entries = (
+                branded_provider.get("api-key-entries", [])
+                if isinstance(branded_provider, dict)
+                else []
+            )
+            if (
+                not isinstance(branded_provider, dict)
+                or branded_provider.get("base-url") != base_url
+                or not any(
+                    isinstance(entry, dict) and entry.get("api-key") == api_key
+                    for entry in branded_entries
+                )
+            ):
+                raise AssertionError(
+                    "OpenAI Compatibility PUT payload dropped configured branded provider "
+                    f"{provider_name!r}: {payload!r}"
+                )
 
 
 def assert_config_yaml_roundtrip(state: MockCoreState) -> None:
@@ -1654,6 +1719,74 @@ def run_usage_service_tier_smoke(page: Any) -> None:
     page.set_viewport_size({"width": 1280, "height": 720})
 
 
+def run_branded_provider_visibility_smoke(
+    page: Any,
+    app_url: str,
+    state: MockCoreState,
+) -> None:
+    branded_labels = ["ClaudeAPI", "Code0", "FennoAI", "Qiniu Cloud"]
+
+    for label in branded_labels:
+        category = page.get_by_role(
+            "button",
+            name=re.compile(rf"^{re.escape(label)}(?:\s|$)", re.I),
+        )
+        category.wait_for()
+        category.click()
+        page.get_by_role("heading", name=label, exact=True).wait_for()
+        for action in ["View", "Edit", "Delete"]:
+            action_buttons = page.get_by_role("button", name=action, exact=True)
+            action_buttons.first.wait_for()
+            if action_buttons.count() != 1:
+                raise AssertionError(
+                    f"Configured branded provider {label!r} should expose exactly one "
+                    f"{action!r} action; found {action_buttons.count()}"
+                )
+            if not action_buttons.first.is_enabled():
+                raise AssertionError(
+                    f"Configured branded provider {label!r} has disabled {action!r} action"
+                )
+
+    body_text = page.locator("body").inner_text()
+    for forbidden_text in ["Quick" + " Fill", "Register" + " here"]:
+        if forbidden_text in body_text:
+            raise AssertionError(
+                f"Provider workbench rendered removed promotional text: {forbidden_text!r}"
+            )
+
+    state.include_branded_providers = False
+    try:
+        page.goto(
+            f"{app_url}?route=workbench-no-brands#/ai-providers/workbench",
+            wait_until="domcontentloaded",
+        )
+        page.wait_for_function("() => window.location.hash.endsWith('/ai-providers/workbench')")
+        page.get_by_text("AI Providers", exact=False).first.wait_for()
+        page.get_by_role("button", name=re.compile(r"^Gemini(?:\s|$)", re.I)).wait_for()
+
+        for label in branded_labels:
+            category = page.get_by_role(
+                "button",
+                name=re.compile(rf"^{re.escape(label)}(?:\s|$)", re.I),
+            )
+            if category.count() != 0:
+                raise AssertionError(
+                    f"Unconfigured branded provider {label!r} was shown as a recommendation"
+                )
+
+        body_text = page.locator("body").inner_text()
+        for forbidden_text in ["Quick" + " Fill", "Register" + " here"]:
+            if forbidden_text in body_text:
+                raise AssertionError(
+                    f"Unconfigured provider workbench rendered promotional text: "
+                    f"{forbidden_text!r}"
+                )
+        if page.locator('a[href*="quick-start"]').count() != 0:
+            raise AssertionError("Unconfigured provider workbench exposed a quick-start route")
+    finally:
+        state.include_branded_providers = True
+
+
 def run_browser_smoke(app_url: str, api_url: str, state: MockCoreState, headed: bool) -> None:
     try:
         from playwright.sync_api import Error as PlaywrightError
@@ -1838,6 +1971,8 @@ def run_browser_smoke(app_url: str, api_url: str, state: MockCoreState, headed: 
             ):
                 sheet.get_by_role("button", name="Save").click()
             wait_for_no_dialog()
+
+            run_branded_provider_visibility_smoke(page, app_url, state)
 
             page.goto(f"{app_url}?route=config-source-save#/config", wait_until="domcontentloaded")
             page.wait_for_function("() => window.location.hash.endsWith('/config')")

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1053,7 +1053,7 @@
     "model_price_cache": "Cache read price",
     "model_price_cache_write": "Cache write price",
     "model_price_cache_write_auto": "Auto",
-    "model_price_cache_write_hint": "Leave blank to use prompt price ×1.25 for GPT-5.6; other models reuse the cache read price.",
+    "model_price_cache_write_hint": "Leave blank to use prompt price ×1.25 for GPT-5.6. Other models add no cache-write cost unless you enter one.",
     "model_price_save": "Save Price",
     "model_price_empty": "No model prices set",
     "model_price_model": "Model",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -1047,7 +1047,7 @@
     "model_price_cache": "Цена чтения из кэша",
     "model_price_cache_write": "Цена записи в кэш",
     "model_price_cache_write_auto": "Авто",
-    "model_price_cache_write_hint": "Если поле пустое, для GPT-5.6 используется цена prompt ×1,25; для других моделей — цена чтения из кэша.",
+    "model_price_cache_write_hint": "Если поле пустое, для GPT-5.6 используется цена prompt ×1,25; для других моделей стоимость записи в кэш не добавляется, если она не указана явно.",
     "model_price_save": "Сохранить цену",
     "model_price_empty": "Цена для моделей не задана",
     "model_price_model": "Модель",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1053,7 +1053,7 @@
     "model_price_cache": "缓存读取价格",
     "model_price_cache_write": "缓存写入价格",
     "model_price_cache_write_auto": "自动",
-    "model_price_cache_write_hint": "留空时 GPT-5.6 按提示价格的 1.25 倍计算，其他模型沿用缓存读取价格。",
+    "model_price_cache_write_hint": "留空时 GPT-5.6 按提示价格的 1.25 倍计算；其他模型默认不新增缓存写入成本，如需计费请显式填写。",
     "model_price_save": "保存价格",
     "model_price_empty": "暂未设置任何模型价格",
     "model_price_model": "模型",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1079,7 +1079,7 @@
     "model_price_cache": "快取讀取定價",
     "model_price_cache_write": "快取寫入定價",
     "model_price_cache_write_auto": "自動",
-    "model_price_cache_write_hint": "留空時 GPT-5.6 按提示定價的 1.25 倍計算，其他模型沿用快取讀取定價。",
+    "model_price_cache_write_hint": "留空時 GPT-5.6 按提示定價的 1.25 倍計算；其他模型預設不新增快取寫入成本，如需計費請明確填寫。",
     "model_price_save": "儲存定價",
     "model_price_empty": "尚未設定任何模型定價",
     "model_price_model": "模型",

--- a/src/utils/usage.ts
+++ b/src/utils/usage.ts
@@ -13,9 +13,9 @@ import {
   finalizeLatencyStats,
 } from './usage/latency';
 import {
-  calculateFallbackUsageTotalTokens,
   calculateUsageCost,
   getUsageCacheTokenCounts,
+  resolveUsageTotalTokens,
   type UsageTokenFields,
 } from './usage/cacheTokens';
 import { maskApiKey } from './format';
@@ -728,12 +728,9 @@ export function extractTotalTokens(detail: unknown, modelNameOverride?: string):
   const record = isRecord(detail) ? detail : null;
   const tokensRaw = record?.tokens;
   const tokens = isRecord(tokensRaw) ? tokensRaw : {};
-  if (typeof tokens.total_tokens === 'number') {
-    return tokens.total_tokens;
-  }
   const modelName =
     modelNameOverride ?? (typeof record?.__modelName === 'string' ? record.__modelName : '');
-  return calculateFallbackUsageTotalTokens(tokens, modelName);
+  return resolveUsageTotalTokens(tokens, modelName);
 }
 
 /**

--- a/src/utils/usage/cacheTokens.test.mjs
+++ b/src/utils/usage/cacheTokens.test.mjs
@@ -15,6 +15,7 @@ const {
   calculateUsageCost,
   getUsageCacheTokenCounts,
   isGpt56CacheWriteModel,
+  resolveUsageTotalTokens,
   resolveCacheWriteUnitPrice,
   splitUsageTokensForCost,
 } = await import(`data:text/javascript;base64,${Buffer.from(compiled).toString('base64')}`);
@@ -92,6 +93,17 @@ test('Core GPT-5.6 usage fixture keeps cache read and write independent', () => 
   assert.equal(calculateFallbackUsageTotalTokens(tokens, 'gpt-5.6-sol'), 1210);
 });
 
+test('explicit Core totals win while missing-total legacy details use the Panel fallback', () => {
+  const tokens = {
+    input_tokens: 1200,
+    output_tokens: 10,
+    cache_creation_tokens: 1024,
+  };
+
+  assert.equal(resolveUsageTotalTokens({ ...tokens, total_tokens: 2234 }, 'gpt-5.6-sol'), 2234);
+  assert.equal(resolveUsageTotalTokens(tokens, 'gpt-5.6-sol'), 1210);
+});
+
 test('non GPT-5.6 models preserve the existing prompt-minus-cache-read behavior', () => {
   const split = splitUsageTokensForCost(
     {
@@ -115,18 +127,40 @@ test('non GPT-5.6 models preserve the existing prompt-minus-cache-read behavior'
     'claude-sonnet-4-5',
     { prompt: 10, completion: 20, cache: 1 }
   );
-  assert.ok(Math.abs(cost - 0.00117) < 1e-12, `cost = ${cost}, want approximately 0.00117`);
+  assert.ok(Math.abs(cost - 0.00113) < 1e-12, `cost = ${cost}, want approximately 0.00113`);
+
+  const configuredWriteCost = calculateUsageCost(
+    {
+      input_tokens: 100,
+      output_tokens: 20,
+      cache_read_tokens: 30,
+      cache_creation_tokens: 40,
+    },
+    'claude-sonnet-4-5',
+    { prompt: 10, completion: 20, cache: 1, cacheWrite: 2 }
+  );
+  assert.ok(
+    Math.abs(configuredWriteCost - 0.00121) < 1e-12,
+    `cost = ${configuredWriteCost}, want approximately 0.00121`
+  );
 });
 
-test('GPT-5.6 variants and Codex family aliases receive the 1.25x default write price', () => {
-  for (const model of ['gpt-5.6-sol', 'openai/gpt-5.6-terra', 'luna']) {
+test('only explicit GPT-5.6 model slugs receive the 1.25x default write price', () => {
+  for (const model of ['gpt-5.6-sol', 'openai/gpt-5.6-terra', 'custom:gpt-5.6-luna']) {
     assert.equal(isGpt56CacheWriteModel(model), true);
     assert.equal(resolveCacheWriteUnitPrice(model, 10, 1), 12.5);
   }
 
+  for (const model of ['sol', 'luna', 'vendor/luna', 'custom:terra']) {
+    assert.equal(isGpt56CacheWriteModel(model), false);
+    assert.equal(resolveCacheWriteUnitPrice(model, 10, 1), 0);
+  }
+
   assert.equal(resolveCacheWriteUnitPrice('gpt-5.6-sol', 10, 1, 7), 7);
   assert.equal(resolveCacheWriteUnitPrice('gpt-5.6-sol', 10, 1, 0), 0);
-  assert.equal(resolveCacheWriteUnitPrice('claude-sonnet-4-5', 10, 1), 1);
+  assert.equal(resolveCacheWriteUnitPrice('claude-sonnet-4-5', 10, 1), 0);
+  assert.equal(resolveCacheWriteUnitPrice('claude-sonnet-4-5', 10, 1, 2), 2);
+  assert.equal(resolveCacheWriteUnitPrice('claude-sonnet-4-5', 10, 1, 0), 0);
 });
 
 test('cost calculation prices normal input, cache read, cache write, and output independently', () => {

--- a/src/utils/usage/cacheTokens.ts
+++ b/src/utils/usage/cacheTokens.ts
@@ -32,7 +32,6 @@ export interface UsagePriceFields {
 const TOKENS_PER_PRICE_UNIT = 1_000_000;
 
 const GPT_56_MODEL_PATTERN = /(?:^|[/:])gpt-5\.6(?:$|[-_.:/])/;
-const GPT_56_CODEX_ALIASES = new Set(['sol', 'terra', 'luna']);
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === 'object' && !Array.isArray(value);
@@ -65,10 +64,7 @@ export function getUsageCacheTokenCounts(tokens: unknown): UsageCacheTokenCounts
 export function isGpt56CacheWriteModel(modelName: string): boolean {
   const normalized = modelName.trim().toLowerCase();
   if (!normalized) return false;
-  if (GPT_56_MODEL_PATTERN.test(normalized)) return true;
-
-  const modelSegments = normalized.split(/[/:]/).filter(Boolean);
-  return modelSegments.some((segment) => GPT_56_CODEX_ALIASES.has(segment));
+  return GPT_56_MODEL_PATTERN.test(normalized);
 }
 
 export function splitUsageTokensForCost(
@@ -103,10 +99,15 @@ export function calculateFallbackUsageTotalTokens(
   return inputTokens + outputTokens + reasoningTokens + cacheTokens;
 }
 
+export function resolveUsageTotalTokens(tokens: UsageTokenFields, modelName: string): number {
+  const explicitTotal = toOptionalTokenCount(tokens.total_tokens);
+  return explicitTotal ?? calculateFallbackUsageTotalTokens(tokens, modelName);
+}
+
 export function resolveCacheWriteUnitPrice(
   modelName: string,
   promptUnitPrice: number,
-  cacheReadUnitPrice: number,
+  _cacheReadUnitPrice: number,
   configuredCacheWriteUnitPrice?: number
 ): number {
   if (
@@ -122,7 +123,7 @@ export function resolveCacheWriteUnitPrice(
     return prompt * 1.25;
   }
 
-  return Number.isFinite(cacheReadUnitPrice) ? Math.max(cacheReadUnitPrice, 0) : 0;
+  return 0;
 }
 
 export function calculateUsageCost(


### PR DESCRIPTION
## 结果与关键边界

本 PR 修复 PR #12 合入后复核发现的 usage 定价兼容性和 GPT-5.6 模型识别问题，并把对应回归接入默认验证、GitHub CI 与浏览器 smoke。

- 仅修改 CPA-Panel-LTS，不修改 Core、Management API endpoint 或 usage export version。
- 不打 tag、不发布 Release、不部署 `management.html`。
- 本 PR 是独立 correctness follow-up，不包含 Draft PR #14 的 usage import、reasoning effort 或 xAI 改动；由于两者重叠若干维护文件，#14 需要在本 PR 合并后 rebase 并重新验证。
- PR 已 Ready，但在 GitHub checks 全部通过并重新确认 head SHA 前不会合并。

## 问题与根因

1. 非 GPT-5.6 模型在未显式配置 `cacheWrite` 时错误复用了 cache-read 单价，导致 Claude 等模型在原有 prompt 成本之外新增 cache-write 成本。
2. 裸 `sol`、`terra`、`luna` alias 会把任意 generic model 误判为 GPT-5.6，从而错误套用 token split 和 1.25× cache-write 定价。
3. Panel 对显式 `total_tokens` 与 missing-total fallback 的边界没有独立可测试入口，容易误报与 Core fallback 完全一致。
4. `test:usage-cache` 未进入 `validate:lts` 和 GitHub Actions，branded provider 的配置识别也缺少自动浏览器保护。

## 变更

### Cache-write 定价和模型识别

- 只有包含完整 `gpt-5.6` slug 的模型才启用 GPT-5.6 语义，例如 `gpt-5.6-sol`、`openai/gpt-5.6-terra`。
- `luna`、`vendor/luna`、`custom:terra` 等普通模型不再被误判。
- GPT-5.6 未配置 `cacheWrite` 时继续使用 prompt input 单价的 1.25×。
- 非 GPT-5.6 未配置 `cacheWrite` 时默认新增价格为 0，保持旧 Panel 行为；显式正数或显式 0 始终优先。
- 四套 active locale 同步更新定价提示。

### Token total 边界

- 新增 `resolveUsageTotalTokens`：显式 `total_tokens` 始终优先，只有字段缺失时才使用 model-aware Panel fallback。
- 不声称 Panel missing-total fallback 与 Core 完全统一；当前 Core 返回的显式总量保持权威。

### 自动化保护

- 扩展 usage-cache regression，覆盖 canonical/legacy cache 字段、显式 0、GPT-5.6 namespace、generic alias、非 GPT 定价和 total fallback。
- 将 `npm run test:usage-cache` 接入 `validate:lts` 和 `lts-panel-contract` workflow。
- 同步更新 feature contract 和 LTS guard，防止测试门禁被静默移除。
- mock browser smoke 新增 ClaudeAPI、Code0、FennoAI、Qiniu Cloud 已配置状态，并验证每组 View/Edit/Delete。
- 验证 generic OpenAI Compatibility 编辑不会丢失 branded provider 配置；无 branded 配置时不显示品牌推荐、Quick Fill、注册链接或 quick-start 路由。

## 兼容性

- `/usage`、完整 usage statistics、import/export、service tier、cache read/write 展示和本地价格设置保持存在。
- 非 GPT-5.6 模型继续使用原有 prompt-minus-cache-read 语义。
- 旧 localStorage price object 不含 `cacheWrite` 时继续可读。
- 显式 `cacheWrite: 0`、`cache_read_tokens: 0` 和 `cache_creation_tokens: 0` 均保持最高优先级。
- provider workbench、provider status bar、plugin capability gate 和 `management.html` contract 均未弱化。

## 本地验证

以下命令已在最终 commit `e62acd3c505e2916d51030f8b9addba9ee91efed` 上通过：

- `npm run validate:lts`
  - usage-cache tests：7/7 passed
  - feature/LTS contract、type-check、ESLint、production build passed
- `npm run smoke:lts`
  - usage service-tier/cache combined fixture、CSV/JSON export、窄屏布局 passed
  - provider CRUD/model discovery、branded configured/unconfigured regression passed
- `npm run smoke:lts:core -- --no-write-smoke`
  - 使用 Core `origin/main@2c11ea9511ce580042caa09cbfda46be8d22e235` 的临时归档副本
  - Management usage/import/export、provider、plugin、config、logs 和 browser flows passed
- `git diff --check`
- `dist/index.html` required marker scan：8/8 present；promotion/affiliate/quick-start forbidden marker：0 present

GitHub checks 尚待本 PR 创建后回读，不在此处预先声称通过。

## Review focus

1. 确认非 GPT-5.6 默认 cache-write 价格为 0，且显式 `cacheWrite`（包括 0）仍优先。
2. 确认 GPT-5.6 检测只匹配完整 slug，不再依赖裸 Sol/Terra/Luna alias。
3. 确认显式 Core `total_tokens` 优先，Panel fallback 仅用于缺失字段。
4. 确认 CI/contract 和 branded provider smoke 覆盖没有弱化 commercial-neutral、full usage 或 provider workbench 边界。
