### PR TITLE
style(config): 调整配置页与可视化编辑器强调色

### DIFF
--- a/src/components/config/VisualConfigEditor.module.scss
+++ b/src/components/config/VisualConfigEditor.module.scss
@@ -2,10 +2,10 @@
 @use '../../styles/variables' as *;
 
 .visualEditor {
-  --config-accent: #3f7f78;
-  --config-accent-strong: #2f6b65;
-  --config-accent-soft: color-mix(in srgb, var(--config-accent) 11%, transparent);
-  --config-accent-border: color-mix(in srgb, var(--config-accent) 32%, var(--border-color));
+  --config-accent: #526b94;
+  --config-accent-strong: #344b70;
+  --config-accent-surface: color-mix(in srgb, var(--bg-primary) 94%, var(--config-accent) 6%);
+  --config-accent-border: color-mix(in srgb, var(--border-color) 78%, var(--config-accent) 22%);
   --config-gold: #a8792e;
 
   display: flex;
@@ -474,7 +474,7 @@
 }
 
 .navButtonActive {
-  background: var(--config-accent-soft);
+  background: var(--config-accent-surface);
 
   &::before {
     position: absolute;
@@ -603,7 +603,7 @@
   border-bottom: 1px solid var(--border-color);
   background: linear-gradient(
     180deg,
-    color-mix(in srgb, var(--config-accent) 4%, transparent),
+    color-mix(in srgb, var(--text-primary) 2%, transparent),
     transparent 82%
   );
 }
@@ -641,7 +641,7 @@
 
 .systemTabActive {
   border-color: var(--config-accent-border);
-  background: var(--config-accent-soft);
+  background: var(--config-accent-surface);
   color: var(--config-accent-strong);
   box-shadow: inset 0 -2px 0 var(--config-accent);
 }
@@ -692,7 +692,7 @@
   width: 34px;
   height: 34px;
   border-radius: 7px;
-  background: var(--config-accent-soft);
+  background: color-mix(in srgb, var(--bg-primary) 88%, var(--config-accent) 12%);
   color: var(--config-accent-strong);
   flex: 0 0 auto;
 }
@@ -1297,10 +1297,10 @@
 }
 
 :global([data-theme='dark']) .visualEditor {
-  --config-accent: #69aaa2;
-  --config-accent-strong: #8dc3bd;
-  --config-accent-soft: color-mix(in srgb, var(--config-accent) 14%, transparent);
-  --config-accent-border: color-mix(in srgb, var(--config-accent) 42%, var(--border-color));
+  --config-accent: #58719a;
+  --config-accent-strong: #b6c3dc;
+  --config-accent-surface: color-mix(in srgb, var(--bg-primary) 88%, var(--config-accent) 12%);
+  --config-accent-border: color-mix(in srgb, var(--border-color) 62%, var(--config-accent) 38%);
   --config-gold: #d5b36d;
 }
 

--- a/src/pages/ConfigPage.module.scss
+++ b/src/pages/ConfigPage.module.scss
@@ -2,10 +2,11 @@
 @use '../styles/variables' as *;
 
 .container {
-  --config-accent: #3f7f78;
-  --config-accent-strong: #2f6b65;
-  --config-accent-soft: color-mix(in srgb, var(--config-accent) 12%, transparent);
-  --config-accent-border: color-mix(in srgb, var(--config-accent) 32%, var(--border-color));
+  --config-accent: #526b94;
+  --config-accent-strong: #344b70;
+  --config-accent-hover: #425b86;
+  --config-accent-surface: color-mix(in srgb, var(--bg-primary) 94%, var(--config-accent) 6%);
+  --config-accent-border: color-mix(in srgb, var(--border-color) 78%, var(--config-accent) 22%);
 
   width: min(100%, 1480px);
   min-height: 100%;
@@ -92,7 +93,7 @@
 
 .tabActive {
   color: var(--config-accent-strong);
-  background: var(--config-accent-soft);
+  background: var(--config-accent-surface);
   border-color: var(--config-accent-border);
   box-shadow: inset 0 -2px 0 var(--config-accent);
 }
@@ -302,10 +303,11 @@
 }
 
 .actionBar {
-  --config-accent: #3f7f78;
-  --config-accent-strong: #2f6b65;
-  --config-accent-soft: color-mix(in srgb, var(--config-accent) 12%, transparent);
-  --config-accent-border: color-mix(in srgb, var(--config-accent) 32%, var(--border-color));
+  --config-accent: #526b94;
+  --config-accent-strong: #344b70;
+  --config-accent-hover: #425b86;
+  --config-accent-surface: color-mix(in srgb, var(--bg-primary) 94%, var(--config-accent) 6%);
+  --config-accent-border: color-mix(in srgb, var(--border-color) 78%, var(--config-accent) 22%);
 
   position: fixed;
   left: var(--content-center-x, 50%);
@@ -318,8 +320,7 @@
   width: min(
     1480px,
     calc(
-      200vw - var(--content-center-x, 50vw) - var(--content-center-x, 50vw) -
-        clamp(40px, 6vw, 96px)
+      200vw - var(--content-center-x, 50vw) - var(--content-center-x, 50vw) - clamp(40px, 6vw, 96px)
     )
   );
   max-width: calc(100vw - 24px);
@@ -397,7 +398,7 @@
 
   &:hover:not(:disabled) {
     border-color: var(--config-accent-border);
-    background: var(--config-accent-soft);
+    background: var(--config-accent-surface);
     color: var(--config-accent-strong);
     transform: translateY(-1px);
   }
@@ -420,8 +421,8 @@
   color: #fff;
 
   &:hover:not(:disabled) {
-    border-color: var(--config-accent-strong);
-    background: var(--config-accent-strong);
+    border-color: var(--config-accent-hover);
+    background: var(--config-accent-hover);
     color: #fff;
   }
 }
@@ -467,10 +468,11 @@
 
 :global([data-theme='dark']) .container,
 :global([data-theme='dark']) .actionBar {
-  --config-accent: #69aaa2;
-  --config-accent-strong: #8dc3bd;
-  --config-accent-soft: color-mix(in srgb, var(--config-accent) 14%, transparent);
-  --config-accent-border: color-mix(in srgb, var(--config-accent) 42%, var(--border-color));
+  --config-accent: #58719a;
+  --config-accent-strong: #b6c3dc;
+  --config-accent-hover: #425b86;
+  --config-accent-surface: color-mix(in srgb, var(--bg-primary) 88%, var(--config-accent) 12%);
+  --config-accent-border: color-mix(in srgb, var(--border-color) 62%, var(--config-accent) 38%);
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## 结果

将配置工作区原有的青绿色强调色调整为低饱和蓝色，并统一配置页与可视化编辑器的 active、hover、focus、surface 和 border 状态。改动仅涉及两个 SCSS 文件，不改变配置行为、API、数据结构、locale 或 LTS contract。

## 变更

- Light theme 使用 `#526b94` accent、`#344b70` strong 和 `#425b86` hover。
- Dark theme 使用 `#58719a` accent、`#b6c3dc` strong，并保留独立的深色 hover token。
- active surface 改为基于 `--bg-primary` 与 accent 的稳定混色，避免透明背景在不同容器上产生不一致效果。
- Primary Save action 使用独立 hover token；键盘 focus ring 和 disabled 状态保持清晰。

## 兼容性与边界

- 不修改 React 组件逻辑、配置解析、Management API、Core contract 或用户数据。
- 不修改全局 theme token，不引入新依赖。
- 不包含 `dist/`、浏览器截图或本地生成材料。
- 本 PR 不创建 tag、release，不执行 Docker publish 或 HF deployment。

## 验证

- `npm run validate:lts`
  - usage tests passed
  - LTS panel contract passed
  - type-check passed
  - lint passed
  - production build passed
- `npm run smoke:lts` passed against the local mock Core API.
- Browser visual review covered Light/Dark at `1280x720` and `390x844`; no horizontal overflow, text clipping, unclear selected state, or missing focus indication was observed.
- Contrast checks:
  - accent text/background: approximately `7.05–8.63:1`
  - white primary-action text: approximately `4.95–6.84:1`
  - dark focus accent/background: approximately `3.47:1`
- `git diff --check origin/main...HEAD` passed.
