### PR TITLE
fix(config): align retry stream buffer safety

### DIFF
--- a/src/components/config/VisualConfigEditor.tsx
+++ b/src/components/config/VisualConfigEditor.tsx
@@ -1777,7 +1777,7 @@ export function VisualConfigEditor({
                                 'config_management.visual.sections.headers.codex_abnormal_reasoning_retry_stream_buffer_max_bytes_label'
                               )}
                               type="number"
-                              placeholder="0"
+                              placeholder="16777216"
                               value={values.codexAbnormalReasoningRetryStreamBufferMaxBytes}
                               onChange={(e) =>
                                 onChange({

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1409,7 +1409,7 @@
           "codex_abnormal_reasoning_retry_stream_buffer": "Buffer Streaming Responses",
           "codex_abnormal_reasoning_retry_stream_buffer_desc": "Hold streaming chunks until response.completed so matching abnormal responses can be retried transparently",
           "codex_abnormal_reasoning_retry_stream_buffer_max_bytes_label": "Stream buffer max bytes",
-          "codex_abnormal_reasoning_retry_stream_buffer_max_bytes_hint": "0 means unlimited buffering; positive values flush and fall back to pass-through for the current stream once exceeded",
+          "codex_abnormal_reasoning_retry_stream_buffer_max_bytes_hint": "Defaults to 16 MiB (16777216); 0 also uses the safe default. Exceeding the limit fails the stream closed with 502 and never passes through partial output",
           "codex_abnormal_reasoning_retry_hedged_retry_enabled": "Enable Hedged Retry",
           "codex_abnormal_reasoning_retry_hedged_retry_enabled_desc": "After the first abnormal response is discarded, launch a delayed second lane to reduce tail latency",
           "codex_abnormal_reasoning_retry_hedged_retry_mode_label": "Hedged retry mode",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -1403,7 +1403,7 @@
           "codex_abnormal_reasoning_retry_stream_buffer": "Буферизовать потоковые ответы",
           "codex_abnormal_reasoning_retry_stream_buffer_desc": "Сохраняет потоковые фрагменты до завершения ответа, чтобы не доставлять аномальный ответ слишком рано",
           "codex_abnormal_reasoning_retry_stream_buffer_max_bytes_label": "Лимит буфера потока в байтах",
-          "codex_abnormal_reasoning_retry_stream_buffer_max_bytes_hint": "0 означает без лимита; положительное значение очищает буфер при превышении и пропускает текущий поток напрямую",
+          "codex_abnormal_reasoning_retry_stream_buffer_max_bytes_hint": "По умолчанию 16 MiB (16777216); 0 также включает безопасное значение. При превышении поток завершается с 502 без передачи частичного ответа",
           "codex_abnormal_reasoning_retry_hedged_retry_enabled": "Включить параллельный повтор",
           "codex_abnormal_reasoning_retry_hedged_retry_enabled_desc": "После отброшенного аномального ответа запускает второй запрос с задержкой, чтобы снизить хвостовую задержку",
           "codex_abnormal_reasoning_retry_hedged_retry_mode_label": "Режим параллельного повтора",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1409,7 +1409,7 @@
           "codex_abnormal_reasoning_retry_stream_buffer": "缓存流式响应",
           "codex_abnormal_reasoning_retry_stream_buffer_desc": "在响应完成前暂存流式片段，命中异常时可避免提前交付异常内容",
           "codex_abnormal_reasoning_retry_stream_buffer_max_bytes_label": "流式缓存上限字节数",
-          "codex_abnormal_reasoning_retry_stream_buffer_max_bytes_hint": "填 0 表示不限制；填正数表示超出后清空已缓存内容，并让当前流式响应直接透传",
+          "codex_abnormal_reasoning_retry_stream_buffer_max_bytes_hint": "默认 16 MiB（16777216）；填 0 也使用安全默认值。超出后当前流式响应以 502 失败关闭，不会透传部分内容",
           "codex_abnormal_reasoning_retry_hedged_retry_enabled": "启用对冲重试",
           "codex_abnormal_reasoning_retry_hedged_retry_enabled_desc": "首个异常响应被丢弃后，延迟启动第二路请求以降低尾延迟",
           "codex_abnormal_reasoning_retry_hedged_retry_mode_label": "对冲重试模式",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1435,7 +1435,7 @@
           "codex_abnormal_reasoning_retry_stream_buffer": "快取串流回應",
           "codex_abnormal_reasoning_retry_stream_buffer_desc": "在回應完成前暫存串流片段，命中異常時可避免提前交付異常內容",
           "codex_abnormal_reasoning_retry_stream_buffer_max_bytes_label": "串流快取上限位元組數",
-          "codex_abnormal_reasoning_retry_stream_buffer_max_bytes_hint": "填 0 表示不限制；填正數表示超出後清空已快取內容，並讓目前串流回應直接透傳",
+          "codex_abnormal_reasoning_retry_stream_buffer_max_bytes_hint": "預設 16 MiB（16777216）；填 0 也使用安全預設值。超出後目前串流回應會以 502 失敗關閉，不會透傳部分內容",
           "codex_abnormal_reasoning_retry_hedged_retry_enabled": "啟用對沖重試",
           "codex_abnormal_reasoning_retry_hedged_retry_enabled_desc": "首個異常回應被丟棄後，延遲啟動第二路請求以降低尾端延遲",
           "codex_abnormal_reasoning_retry_hedged_retry_mode_label": "對沖重試模式",

--- a/src/types/visualConfig.ts
+++ b/src/types/visualConfig.ts
@@ -255,7 +255,7 @@ export const DEFAULT_VISUAL_VALUES: VisualConfigValues = {
   codexAbnormalReasoningRetryAuthKinds: ['oauth'],
   codexAbnormalReasoningRetryAuthIds: [],
   codexAbnormalReasoningRetryStreamBuffer: true,
-  codexAbnormalReasoningRetryStreamBufferMaxBytes: '0',
+  codexAbnormalReasoningRetryStreamBufferMaxBytes: '16777216',
   codexAbnormalReasoningRetryMaxRetries: '2',
   codexAbnormalReasoningRetryExhaustedBehavior: 'error',
   codexAbnormalReasoningRetryClientUsageAggregation: 'delivered-only',


### PR DESCRIPTION
## 结论

同步 CPA-Core-LTS `codex.abnormal-reasoning-retry.stream-buffer-max-bytes` 的新安全语义，避免 Panel 继续把 `0` 描述为无限缓冲和超限透传。

## 修改

- Visual Config 默认值与 placeholder 改为 `16777216`（16 MiB）。
- `en`、`zh-CN`、`zh-TW`、`ru` 文案统一说明：`0` 使用安全默认值；超限以 502 fail-closed，不透传 partial output。
- 配置 key 和保存结构不变，已有正整数配置继续兼容。

## 验证

- `npm run validate:lts`
  - usage/provider/API client tests passed
  - Panel LTS contract passed
  - type-check passed
  - lint passed
  - production build passed
- `git diff --check`

## 合并顺序

应在对应 CPA-Core-LTS bounded-memory PR 合入后再合并本 PR，避免短暂出现 UI 文案领先于 Core runtime 语义。