### PR TITLE
fix(usage): accept omitted legacy zero fields

### DIFF
--- a/docs/lts/panel-protected-deltas.yaml
+++ b/docs/lts/panel-protected-deltas.yaml
@@ -16,6 +16,10 @@ protected_deltas:
       - usage Zustand store
       - usage aggregation utilities
       - import/export
+      - canonical version 2 usage export compatibility
+      - safe version 1 migration, including omitted legacy zero fields and fail-closed cache ambiguity
+      - Core-compatible duplicate and overlap identity with uncertain-record disclosure
+      - invalid canonical token rejection before upload
       - request events table
       - model/API/credential breakdowns
       - cached/reasoning token breakdown

--- a/src/utils/usage/importPreflight.test.mjs
+++ b/src/utils/usage/importPreflight.test.mjs
@@ -57,20 +57,22 @@ const v2Tokens = (overrides = {}) => ({
   ...overrides,
 });
 
-const v1Payload = (...details) => ({
+const v1PayloadForModel = (modelName, ...details) => ({
   version: 1,
   usage: {
     apis: {
       'POST /v1/responses': {
         models: {
-          'gpt-5.6-sol': { details },
+          [modelName]: { details },
         },
       },
     },
   },
 });
 
-const v2Payload = (...details) => {
+const v1Payload = (...details) => v1PayloadForModel('gpt-5.6-sol', ...details);
+
+const v2PayloadForModel = (modelName, ...details) => {
   const totalTokens = details.reduce((total, item) => total + item.tokens.total_tokens, 0);
   return {
     version: 2,
@@ -84,7 +86,7 @@ const v2Payload = (...details) => {
           total_requests: details.length,
           total_tokens: totalTokens,
           models: {
-            'gpt-5.6-sol': {
+            [modelName]: {
               total_requests: details.length,
               total_tokens: totalTokens,
               details,
@@ -99,6 +101,8 @@ const v2Payload = (...details) => {
     },
   };
 };
+
+const v2Payload = (...details) => v2PayloadForModel('gpt-5.6-sol', ...details);
 
 const clone = (value) => JSON.parse(JSON.stringify(value));
 
@@ -237,17 +241,22 @@ test('v1 treats omitted legacy zero reasoning and cached fields as zero', () => 
   );
   assert.equal(markerless.valid, true);
 
-  const markerBearing = v1Payload(
-    detail({
-      input_tokens: 3085,
-      output_tokens: 253,
-      cache_read_tokens: 7,
-      cache_creation_tokens: 19514,
-      uncached_input_tokens: 3085,
-      total_tokens: 22859,
-    })
+  const markerBearing = v1PayloadForModel(
+    'claude-sonnet-4-5',
+    detail(
+      {
+        input_tokens: 3085,
+        output_tokens: 253,
+        cache_read_tokens: 7,
+        cache_creation_tokens: 19514,
+        uncached_input_tokens: 3085,
+        total_tokens: 22859,
+      },
+      { source: 'auths/claude.json' }
+    )
   );
-  const canonicalCurrent = v2Payload(
+  const canonicalCurrent = v2PayloadForModel(
+    'claude-sonnet-4-5',
     detail(
       v2Tokens({
         input_tokens: 22606,
@@ -256,7 +265,8 @@ test('v1 treats omitted legacy zero reasoning and cached fields as zero', () => 
         cache_read_tokens: 7,
         cache_creation_tokens: 19514,
         total_tokens: 22859,
-      })
+      }),
+      { source: 'auths/claude.json' }
     )
   ).usage;
   const projected = analyzeUsageImport(markerBearing, canonicalCurrent);
@@ -303,9 +313,21 @@ test('v1 validates legacy required fields and uncached marker bounds before cano
     delete missingField.usage.apis['POST /v1/responses'].models['gpt-5.6-sol'].details[0].tokens[
       field
     ];
-    assert.deepEqual(analyzeUsageImport(missingField).issues, [
-      'usage_v1_token_contract_invalid',
-    ]);
+    assert.deepEqual(analyzeUsageImport(missingField).issues, ['usage_v1_token_contract_invalid']);
+  }
+
+  for (const field of [
+    'reasoning_tokens',
+    'cached_tokens',
+    'cache_read_tokens',
+    'cache_creation_tokens',
+  ]) {
+    for (const invalid of [null, '0', -1, 1.5, Number.MAX_SAFE_INTEGER + 1]) {
+      const invalidOptional = v1Payload(detail(v1Tokens({ [field]: invalid })));
+      assert.deepEqual(analyzeUsageImport(invalidOptional).issues, [
+        'usage_v1_token_contract_invalid',
+      ]);
+    }
   }
 });
 

--- a/src/utils/usage/importPreflight.test.mjs
+++ b/src/utils/usage/importPreflight.test.mjs
@@ -231,7 +231,40 @@ test('v1 safe matrix accepts markerless no-cache details and rejects markerless 
   }
 });
 
-test('v1 validates required fields and uncached marker bounds before canonical migration', () => {
+test('v1 treats omitted legacy zero reasoning and cached fields as zero', () => {
+  const markerless = analyzeUsageImport(
+    v1Payload(detail({ input_tokens: 10, output_tokens: 1, total_tokens: 11 }))
+  );
+  assert.equal(markerless.valid, true);
+
+  const markerBearing = v1Payload(
+    detail({
+      input_tokens: 3085,
+      output_tokens: 253,
+      cache_read_tokens: 7,
+      cache_creation_tokens: 19514,
+      uncached_input_tokens: 3085,
+      total_tokens: 22859,
+    })
+  );
+  const canonicalCurrent = v2Payload(
+    detail(
+      v2Tokens({
+        input_tokens: 22606,
+        output_tokens: 253,
+        cached_tokens: 7,
+        cache_read_tokens: 7,
+        cache_creation_tokens: 19514,
+        total_tokens: 22859,
+      })
+    )
+  ).usage;
+  const projected = analyzeUsageImport(markerBearing, canonicalCurrent);
+  assert.equal(projected.valid, true);
+  assert.equal(projected.overlapCount, 1);
+});
+
+test('v1 validates legacy required fields and uncached marker bounds before canonical migration', () => {
   const valid = analyzeUsageImport(
     v1Payload(
       detail(
@@ -265,10 +298,15 @@ test('v1 validates required fields and uncached marker bounds before canonical m
     assert.deepEqual(result.issues, ['usage_v1_token_contract_invalid']);
   }
 
-  const missingField = v1Payload(detail(v1Tokens()));
-  delete missingField.usage.apis['POST /v1/responses'].models['gpt-5.6-sol'].details[0].tokens
-    .reasoning_tokens;
-  assert.deepEqual(analyzeUsageImport(missingField).issues, ['usage_v1_token_contract_invalid']);
+  for (const field of ['input_tokens', 'output_tokens', 'total_tokens']) {
+    const missingField = v1Payload(detail(v1Tokens()));
+    delete missingField.usage.apis['POST /v1/responses'].models['gpt-5.6-sol'].details[0].tokens[
+      field
+    ];
+    assert.deepEqual(analyzeUsageImport(missingField).issues, [
+      'usage_v1_token_contract_invalid',
+    ]);
+  }
 });
 
 test('v1 released marker fixtures project to the same canonical v2 identities', () => {

--- a/src/utils/usage/importPreflight.ts
+++ b/src/utils/usage/importPreflight.ts
@@ -53,6 +53,14 @@ const REQUIRED_TOKEN_FIELDS = [
 
 const OPTIONAL_TOKEN_FIELDS = ['cache_read_tokens', 'cache_creation_tokens'] as const;
 
+const V1_REQUIRED_TOKEN_FIELDS = ['input_tokens', 'output_tokens', 'total_tokens'] as const;
+
+const V1_OPTIONAL_TOKEN_FIELDS = [
+  'reasoning_tokens',
+  'cached_tokens',
+  ...OPTIONAL_TOKEN_FIELDS,
+] as const;
+
 const SNAPSHOT_INTEGER_FIELDS = [
   'total_requests',
   'success_count',
@@ -210,12 +218,15 @@ const readTokenCounts = (
   const invalidCode: UsageImportPreflightIssue =
     version === 1 ? 'usage_v1_token_contract_invalid' : 'usage_v2_token_contract_invalid';
 
-  for (const key of REQUIRED_TOKEN_FIELDS) {
+  const requiredFields = version === 1 ? V1_REQUIRED_TOKEN_FIELDS : REQUIRED_TOKEN_FIELDS;
+  const optionalFields = version === 1 ? V1_OPTIONAL_TOKEN_FIELDS : OPTIONAL_TOKEN_FIELDS;
+
+  for (const key of requiredFields) {
     if (!hasOwn(value, key) || !isNonNegativeSafeInteger(value[key])) {
       return { tokens: null, issue: invalidCode };
     }
   }
-  for (const key of OPTIONAL_TOKEN_FIELDS) {
+  for (const key of optionalFields) {
     if (hasOwn(value, key) && !isNonNegativeSafeInteger(value[key])) {
       return { tokens: null, issue: invalidCode };
     }


### PR DESCRIPTION
## 变更摘要

修复已合并 PR #39 的 legacy v1 compatibility review finding：version 1 仍要求 `input_tokens`、`output_tokens`、`total_tokens`，但安全省略的零值 `reasoning_tokens` 与 `cached_tokens` 按零处理；version 2 mandatory-field presence 保持不变。

## Baseline / head

- Base：Panel `main` merge `3a8f8d00db34d1018f1434a41363a80c8a092a6a`
- Head：`bf51c9fc304c36303cd4e3a2b62ece6aba41a884`
- Follow-up：#39 discussion `r3631688692`
- Companion Core follow-up：`codex/core-usage-v2-followup`

## Contract decision

- v1 required presence：`input_tokens`、`output_tokens`、`total_tokens`。
- v1 optional legacy zero fields：`reasoning_tokens`、`cached_tokens`、`cache_read_tokens`、`cache_creation_tokens`；若显式出现，仍必须是非负整数，`null`/错误类型继续拒绝。
- v2 仍显式要求 input/output/reasoning/cached/total，omitted 与 explicit zero 继续严格区分。
- markerless/cache-bearing v1 继续 fail closed。
- 不采纳 #39 discussion `r3631688698` 提议的 `uncached + read + creation == legacy input` 约束。released Core `v1-tls-0.0.15` 的 Claude fixture 是 legacy input `3085`、uncached `3085`、read `7`、creation `19514`，规范化 input 为 `22606`；强制相等会拒绝正式发布的可审计备份。

## Red-first evidence

新增 minimal v1 omitted-zero fixture 后，旧实现为 18 项中 1 项失败；生产代码修改后 `npm run test:usage-import` 为 18/18 passed。回归同时覆盖 marker-bearing Claude projection 与 canonical v2 overlap identity。

## Validation

```text
npm run test:usage-import            # 18/18 passed
npm run validate:lts
npm run smoke:lts
npm run smoke:lts:core -- --core-dir "$CORE_FOLLOWUP_DIR" --no-write-smoke
git diff --check
```

Real-Core smoke固定到 companion Core follow-up，验证 schema v2 roundtrip 与 v1 migration receipt。未执行 release 或 deployment。
