### PR TITLE
fix(logs): 替换已完成的尾部未换行日志

### DIFF
--- a/.github/workflows/lts-panel-contract.yml
+++ b/.github/workflows/lts-panel-contract.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Test provider and connection contracts
         run: npm run test:providers && npm run test:auth-files && npm run test:api-client
 
+      - name: Test logs incremental merge semantics
+        run: npm run test:logs
+
       - name: Check LTS panel contract
         run: npm run check:lts
 

--- a/package.json
+++ b/package.json
@@ -25,10 +25,11 @@
     "test:providers": "npm run test:provider-xai && npm run test:provider-integrity && npm run test:provider-recent",
     "test:auth-files": "node --test src/features/authFiles/oauthConfigLoadGuard.test.mjs",
     "test:api-client": "node --test src/services/api/client.test.mjs",
+    "test:logs": "node --test src/utils/logLines.test.mjs",
     "test:usage": "npm run test:usage-cache && npm run test:usage-prices && npm run test:usage-import && npm run test:usage-effort && npm run test:usage-tier && npm run test:usage-pricing-v3 && npm run test:usage-pricing-catalog && npm run test:usage-pricing-storage && npm run test:usage-pricing-integration",
     "check:feature-contract": "node scripts/check-panel-feature-contracts.mjs",
     "check:lts": "scripts/check-lts-panel-contract.sh",
-    "validate:lts": "npm run test:usage && npm run test:providers && npm run test:auth-files && npm run test:api-client && npm run check:lts && npm run type-check && npm run lint && npm run build",
+    "validate:lts": "npm run test:usage && npm run test:providers && npm run test:auth-files && npm run test:api-client && npm run test:logs && npm run check:lts && npm run type-check && npm run lint && npm run build",
     "smoke:lts": "npm run build && python3 scripts/smoke-lts-panel.py",
     "smoke:lts:core": "npm run build && python3 scripts/smoke-lts-panel-core.py"
   },

--- a/src/pages/LogsPage.tsx
+++ b/src/pages/LogsPage.tsx
@@ -31,6 +31,7 @@ import { logsApi, type LogsQuery } from '@/services/api/logs';
 import { versionApi } from '@/services/api/version';
 import { copyToClipboard } from '@/utils/clipboard';
 import { getErrorMessage } from '@/utils/helpers';
+import { mergeIncrementalLogLines } from '@/utils/logLines';
 import { downloadBlob } from '@/utils/download';
 import { MANAGEMENT_API_PREFIX } from '@/utils/constants';
 import { formatUnixTimestamp } from '@/utils/format';
@@ -73,32 +74,6 @@ const buildLogsQuery = (incremental: boolean, position: LogPosition): LogsQuery 
   }
 
   return params;
-};
-
-const findLineOverlap = (currentLines: string[], incomingLines: string[]): number => {
-  const maxOverlap = Math.min(currentLines.length, incomingLines.length);
-
-  for (let size = maxOverlap; size > 0; size -= 1) {
-    let matched = true;
-    for (let i = 0; i < size; i += 1) {
-      if (currentLines[currentLines.length - size + i] !== incomingLines[i]) {
-        matched = false;
-        break;
-      }
-    }
-    if (matched) return size;
-  }
-
-  return 0;
-};
-
-const mergeIncrementalLines = (currentLines: string[], incomingLines: string[]): string[] => {
-  if (currentLines.length === 0 || incomingLines.length === 0) {
-    return [...currentLines, ...incomingLines];
-  }
-
-  const overlap = findLineOverlap(currentLines, incomingLines);
-  return [...currentLines, ...incomingLines.slice(overlap)];
 };
 
 const getErrorPayloadText = (err: unknown): string => {
@@ -284,7 +259,11 @@ export function LogsPage() {
         // 增量更新：追加新日志并限制缓冲区大小（避免内存与渲染膨胀）
         setLogState((prev) => {
           const prevRenderedCount = prev.buffer.length - prev.visibleFrom;
-          const combined = mergeIncrementalLines(prev.buffer, newLines);
+          const combined = mergeIncrementalLogLines(
+            prev.buffer,
+            newLines,
+            data.replaceTrailingPartial
+          );
           const dropCount = Math.max(combined.length - MAX_BUFFER_LINES, 0);
           const buffer = dropCount > 0 ? combined.slice(dropCount) : combined;
           let visibleFrom = Math.max(prev.visibleFrom - dropCount, 0);

--- a/src/services/api/logs.ts
+++ b/src/services/api/logs.ts
@@ -46,6 +46,7 @@ export interface LogsResponse {
   latestAfter?: LogCursor;
   nextCursor?: string;
   cursorReset?: boolean;
+  replaceTrailingPartial?: boolean;
   logBackendKind: LogBackendKind;
   requestLogHomeIpById?: Record<string, string>;
   total?: number;
@@ -113,6 +114,7 @@ const normalizeCPALogs = (data: Record<string, unknown>): LogsResponse => {
     latestAfter: latestTimestamp > 0 ? latestTimestamp : undefined,
     nextCursor: stringValue(data['next-cursor']) || undefined,
     cursorReset: booleanValue(data['cursor-reset']),
+    replaceTrailingPartial: booleanValue(data['replace-trailing-partial']),
     logBackendKind: 'file',
   };
 };

--- a/src/utils/logLines.test.mjs
+++ b/src/utils/logLines.test.mjs
@@ -35,3 +35,14 @@ test('replaces an unchanged preview without duplicating the completed line', () 
     'partial',
   ]);
 });
+
+test('preserves a repeated new line after completing the trailing preview', () => {
+  assert.deepEqual(
+    mergeIncrementalLogLines(
+      ['first', 'partial'],
+      ['partial complete', 'partial complete'],
+      true
+    ),
+    ['first', 'partial complete', 'partial complete']
+  );
+});

--- a/src/utils/logLines.test.mjs
+++ b/src/utils/logLines.test.mjs
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+import ts from 'typescript';
+
+const source = await readFile(new URL('./logLines.ts', import.meta.url), 'utf8');
+const compiled = ts.transpileModule(source, {
+  compilerOptions: {
+    module: ts.ModuleKind.ES2022,
+    target: ts.ScriptTarget.ES2020,
+  },
+}).outputText;
+const { mergeIncrementalLogLines } = await import(
+  `data:text/javascript;base64,${Buffer.from(compiled).toString('base64')}`
+);
+
+test('merges ordinary incremental log overlap without duplicates', () => {
+  assert.deepEqual(mergeIncrementalLogLines(['one', 'two'], ['two', 'three']), [
+    'one',
+    'two',
+    'three',
+  ]);
+});
+
+test('replaces a previewed trailing partial when the completed line arrives', () => {
+  assert.deepEqual(
+    mergeIncrementalLogLines(['first', 'partial'], ['partial complete', 'new'], true),
+    ['first', 'partial complete', 'new']
+  );
+});
+
+test('replaces an unchanged preview without duplicating the completed line', () => {
+  assert.deepEqual(mergeIncrementalLogLines(['first', 'partial'], ['partial'], true), [
+    'first',
+    'partial',
+  ]);
+});

--- a/src/utils/logLines.ts
+++ b/src/utils/logLines.ts
@@ -24,13 +24,13 @@ export function mergeIncrementalLogLines(
     return [...currentLines, ...incomingLines];
   }
 
-  let current = currentLines;
-  let incoming = incomingLines;
   if (replaceTrailingPartial) {
-    current = [...currentLines.slice(0, -1), incomingLines[0]];
-    incoming = incomingLines.slice(1);
+    // The Core cursor already guarantees that every incoming line after the
+    // completed preview is new. Running overlap detection here would collapse
+    // legitimate consecutive log lines with identical text.
+    return [...currentLines.slice(0, -1), ...incomingLines];
   }
 
-  const overlap = findLineOverlap(current, incoming);
-  return [...current, ...incoming.slice(overlap)];
+  const overlap = findLineOverlap(currentLines, incomingLines);
+  return [...currentLines, ...incomingLines.slice(overlap)];
 }

--- a/src/utils/logLines.ts
+++ b/src/utils/logLines.ts
@@ -1,0 +1,36 @@
+const findLineOverlap = (currentLines: string[], incomingLines: string[]): number => {
+  const maxOverlap = Math.min(currentLines.length, incomingLines.length);
+
+  for (let size = maxOverlap; size > 0; size -= 1) {
+    let matched = true;
+    for (let i = 0; i < size; i += 1) {
+      if (currentLines[currentLines.length - size + i] !== incomingLines[i]) {
+        matched = false;
+        break;
+      }
+    }
+    if (matched) return size;
+  }
+
+  return 0;
+};
+
+export function mergeIncrementalLogLines(
+  currentLines: string[],
+  incomingLines: string[],
+  replaceTrailingPartial = false
+): string[] {
+  if (currentLines.length === 0 || incomingLines.length === 0) {
+    return [...currentLines, ...incomingLines];
+  }
+
+  let current = currentLines;
+  let incoming = incomingLines;
+  if (replaceTrailingPartial) {
+    current = [...currentLines.slice(0, -1), incomingLines[0]];
+    incoming = incomingLines.slice(1);
+  }
+
+  const overlap = findLineOverlap(current, incoming);
+  return [...current, ...incoming.slice(overlap)];
+}


### PR DESCRIPTION
## 结果

修复 Management logs 增量轮询中 trailing partial 完成后被重复显示的问题，同时保留完成行之后内容完全相同的合法新日志行。

Core 通过 `replace-trailing-partial: true` 表示 `incoming[0]` 应替换上一轮预览的尾部 partial；Panel 现在显式解析并消费该字段。Replacement 分支直接拼接 `current[:-1] + incoming`，不再对 Core cursor 已确认的新行执行 overlap 去重；ordinary incremental polling 继续使用既有 suffix/prefix overlap。

## 变更

- `src/services/api/logs.ts` 解析 `replace-trailing-partial`。
- `src/pages/LogsPage.tsx` 将该语义传给独立 merge helper。
- `src/utils/logLines.ts` 分离 replacement 与 ordinary overlap，避免吞掉连续相同日志行。
- 增加 ordinary overlap、completed partial、unchanged preview、duplicate-after-completion 四个 regression。
- `package.json` 新增 `test:logs` 并纳入 `validate:lts`。
- `.github/workflows/lts-panel-contract.yml` 显式运行 `npm run test:logs`，确保专用 regression 进入 GitHub CI gate。

## 兼容性与边界

- Baseline：Panel `main` @ `5eab648505b42d10077564a73a744499270b195a`。
- `replace-trailing-partial` 是 additive optional field；旧 Core 不发送时行为不变。
- 配套 Core PR：BlueSkyXN/CPA-Core-LTS#188。合并顺序仍为本 PR 先、Core #188 后。
- 不修改日志文件格式、Management auth、release 或 deployment。

## 验证

- `npm run test:logs`：4/4 passed
- `npm run validate:lts`：passed
- `npm run smoke:lts`：passed
- `git diff --check`：passed

## 剩余验证边界

Mock browser smoke 覆盖 `/logs` route 与 endpoint，但不实际向同一日志文件追加并完成 partial line；精确状态转换由 unit regression 固定。两仓 PR 合入后仍需执行 `npm run smoke:lts:core`。本 PR 未创建 tag、release 或 deployment。

## Review focus

请重点检查 replacement 分支不会吞掉 duplicate new line、cursor reset 优先级、buffer trimming，以及 workflow 中 logs regression 的实际执行。
