### PR TITLE
fix(usage): 修正 OpenAI/Codex 缺失总量时的 reasoning 重计

### DIFF
--- a/src/utils/usage/cacheTokens.test.mjs
+++ b/src/utils/usage/cacheTokens.test.mjs
@@ -120,6 +120,20 @@ test('total fallback does not add cache tokens that normalized input already con
   assert.equal(resolveUsageTotalTokens(tokens, 'any-model'), 1_211);
 });
 
+test('Codex and OpenAI fallback treats reasoning tokens as an output subset', () => {
+  const tokens = {
+    input_tokens: 100,
+    output_tokens: 20,
+    reasoning_tokens: 5,
+  };
+
+  assert.equal(calculateFallbackUsageTotalTokens(tokens, 'gpt-5.6-sol'), 120);
+  assert.equal(calculateFallbackUsageTotalTokens(tokens, 'openai/gpt-5.6-sol'), 120);
+  assert.equal(calculateFallbackUsageTotalTokens(tokens, 'chatgpt-4o-latest'), 120);
+  assert.equal(calculateFallbackUsageTotalTokens(tokens, 'claude-sonnet-4-5'), 125);
+  assert.equal(calculateFallbackUsageTotalTokens(tokens, 'custom/interactions'), 125);
+});
+
 test('explicit cache-write overrides preserve Auto and free semantics', () => {
   assert.equal(resolveCacheWriteUnitPrice('any-model', 10, 1), 10);
   assert.equal(resolveCacheWriteUnitPrice('any-model', 10, 1, 7), 7);

--- a/src/utils/usage/cacheTokens.test.mjs
+++ b/src/utils/usage/cacheTokens.test.mjs
@@ -127,11 +127,35 @@ test('Codex and OpenAI fallback treats reasoning tokens as an output subset', ()
     reasoning_tokens: 5,
   };
 
-  assert.equal(calculateFallbackUsageTotalTokens(tokens, 'gpt-5.6-sol'), 120);
-  assert.equal(calculateFallbackUsageTotalTokens(tokens, 'openai/gpt-5.6-sol'), 120);
-  assert.equal(calculateFallbackUsageTotalTokens(tokens, 'chatgpt-4o-latest'), 120);
-  assert.equal(calculateFallbackUsageTotalTokens(tokens, 'claude-sonnet-4-5'), 125);
-  assert.equal(calculateFallbackUsageTotalTokens(tokens, 'custom/interactions'), 125);
+  for (const modelName of [
+    ' GPT-5.6-SOL ',
+    'chatgpt-4o-latest',
+    'codex-mini-latest',
+    'o1',
+    'o3-mini',
+    'o4',
+    'openai/gpt-5.6-sol',
+    'OPENAI/chatgpt-4o-latest',
+    'openai/codex-mini-latest',
+    'openai/o1',
+    'openai/o3-mini',
+    'openai/o4',
+  ]) {
+    assert.equal(calculateFallbackUsageTotalTokens(tokens, modelName), 120, modelName);
+  }
+
+  for (const modelName of [
+    'o2',
+    'o10',
+    'azure/gpt-5.6-sol',
+    'custom/gpt-5.6-sol',
+    'claude-sonnet-4-5',
+    'custom/interactions',
+  ]) {
+    assert.equal(calculateFallbackUsageTotalTokens(tokens, modelName), 125, modelName);
+  }
+
+  assert.equal(resolveUsageTotalTokens({ ...tokens, total_tokens: 777 }, 'gpt-5.6-sol'), 777);
 });
 
 test('explicit cache-write overrides preserve Auto and free semantics', () => {

--- a/src/utils/usage/cacheTokens.ts
+++ b/src/utils/usage/cacheTokens.ts
@@ -29,6 +29,13 @@ export interface UsagePriceFields {
 
 const TOKENS_PER_PRICE_UNIT = 1_000_000;
 
+const isCodexOrOpenAIReasoningSubsetModel = (modelName: string): boolean => {
+  const normalized = modelName.trim().toLowerCase();
+  return /^(?:gpt-|chatgpt-|codex-|o[134](?:-|$)|openai\/(?:gpt-|chatgpt-|codex-|o[134](?:-|$)))/.test(
+    normalized
+  );
+};
+
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === 'object' && !Array.isArray(value);
 
@@ -79,14 +86,20 @@ export function splitUsageTokensForCost(
 
 export function calculateFallbackUsageTotalTokens(
   tokens: UsageTokenFields,
-  _modelName: string
+  modelName: string
 ): number {
   const inputTokens = toTokenCount(tokens.input_tokens);
   const outputTokens = toTokenCount(tokens.output_tokens);
   const reasoningTokens = toTokenCount(tokens.reasoning_tokens);
 
   // input_tokens is already normalized to include cache reads and writes.
-  return inputTokens + outputTokens + reasoningTokens;
+  // Codex/OpenAI output_tokens already includes reasoning_tokens; other
+  // providers keep reasoning as a separate category.
+  return (
+    inputTokens +
+    outputTokens +
+    (isCodexOrOpenAIReasoningSubsetModel(modelName) ? 0 : reasoningTokens)
+  );
 }
 
 export function resolveUsageTotalTokens(tokens: UsageTokenFields, modelName: string): number {


### PR DESCRIPTION
## 结果

修正 usage detail 缺失 `total_tokens` 时的 fallback：对 OpenAI/Codex 模型按 `input_tokens + output_tokens` 计算，避免把已经包含在 `output_tokens` 内的 `reasoning_tokens` 再加一次。Claude 与无法识别 provider 的模型继续使用 `input_tokens + output_tokens + reasoning_tokens`。

## 变更

- 增加 OpenAI/Codex 模型族的受限识别规则，覆盖 `gpt-*`、`chatgpt-*`、`codex-*`、`o1/o3/o4` 及 `openai/` 前缀。
- 仅在 `total_tokens` 缺失时使用该规则；显式 `total_tokens` 仍为权威值。
- 增加回归测试，固定 OpenAI/Codex 与 Claude/generic 的不同 total fallback 语义。

## 兼容性与边界

- Baseline：`origin/main` @ `5eab648505b42d10077564a73a744499270b195a`。
- 不修改 usage import/export schema、pricing rate、cache token 拆分或 Core API。
- 当前 schema v2 未保存 provider identity，因此此修复仍是 model-name heuristic；在 usage provenance schema v3 完成前，不宣称 unknown model/provider 的 reasoning total provenance 完整。
- 本 PR 未创建 tag、release 或 deployment。

## 验证

- `npm run test:usage-cache`：7/7 passed
- `npm run validate:lts`：passed
- `npm run smoke:lts`：passed
- `git diff --check`：passed

## Review focus

请重点检查 `src/utils/usage/cacheTokens.ts` 的模型匹配边界，以及 unknown model 继续采用 conservative generic fallback 的行为。
