### PR TITLE
ci: 升级 GitHub Actions 的 Node 24 执行 runtime

### DIFF
--- a/.github/workflows/lts-panel-contract.yml
+++ b/.github/workflows/lts-panel-contract.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,13 +20,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
           cache: 'npm'


### PR DESCRIPTION
## 结果

消除主线 CI 中 `actions/checkout@v4`、`actions/setup-node@v4` 使用已弃用 Node 20 action runtime 的平台注解，避免 GitHub 停止强制兼容后 workflow 失效。

## 变更

- `lts-panel-contract.yml`: `actions/checkout` 与 `actions/setup-node` 从 `v4` 升至 `v7`。
- `release.yml`: 同步升级相同 actions，避免未来 tag/release workflow 才暴露 runtime 问题。
- `v7` 的 `action.yml` 已通过 GitHub API readback，二者均声明 `runs.using: node24`。

## 兼容性与边界

- 项目构建 Node 版本仍为 `node-version: '20'`；只升级 action 自身执行 runtime。
- 保留 `npm ci`、`npm run build`、`VERSION`、`v*-tls-*` tag guard、`dist/management.html` 与 `contents: write` 原有契约。
- 不创建 tag、不触发 release、不发布 asset。

## 验证

- GitHub API readback：`actions/checkout@v7`、`actions/setup-node@v7` 均为 Node 24 action runtime。
- `git diff --check`
- `npm run validate:lts`
- 本 PR 的 GitHub Actions 用于验证 workflow YAML、action resolution 和完整 LTS gate。
