### PR TITLE
fix(ui): 移植 Plugin Store 与 Provider URL 响应式样式修复

### DIFF
--- a/src/features/plugins/PluginStorePage.module.scss
+++ b/src/features/plugins/PluginStorePage.module.scss
@@ -328,13 +328,17 @@
 }
 
 .cardHeader {
-  display: flex;
+  display: grid;
+  grid-template-columns: 40px minmax(0, 1fr);
   align-items: flex-start;
-  gap: $spacing-sm;
+  column-gap: $spacing-sm;
+  row-gap: 6px;
 }
 
 .logoBox {
   display: inline-flex;
+  grid-column: 1;
+  grid-row: 1;
   width: 40px;
   height: 40px;
   align-items: center;
@@ -355,7 +359,8 @@
 
 .cardTitleBlock {
   display: flex;
-  flex: 1;
+  grid-column: 2;
+  grid-row: 1;
   flex-direction: column;
   gap: 2px;
   min-width: 0;
@@ -367,7 +372,8 @@
   font-size: 15px;
   font-weight: 650;
   line-height: 1.3;
-  @include text-ellipsis;
+  overflow-wrap: anywhere;
+  @include text-ellipsis-multiline(2);
 }
 
 .cardId {
@@ -379,10 +385,16 @@
 
 .cardBadges {
   display: flex;
+  grid-column: 2;
+  grid-row: 2;
   flex-wrap: wrap;
-  justify-content: flex-end;
+  justify-content: flex-start;
   gap: 5px;
-  flex-shrink: 0;
+  min-width: 0;
+
+  &:empty {
+    display: none;
+  }
 }
 
 .badge,

--- a/src/features/providers/components/ProviderResourceTable.module.scss
+++ b/src/features/providers/components/ProviderResourceTable.module.scss
@@ -37,13 +37,16 @@
 }
 
 .baseUrl {
+  display: block;
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
   font-family: $font-mono;
   font-size: 12px;
   color: var(--muted-foreground);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  max-width: 220px;
 }
 
 .chip {


### PR DESCRIPTION
## 结果

从 upstream 最近 7 天变更中直接移植两个局部、与 LTS usage/API 契约无冲突的响应式样式修复：Plugin Store 卡片标题/徽章不再挤压，Provider resource table 的长 base URL 会在可用列宽内正确省略。

当前仅为已推送 PR；尚未合入 `main`，未 tag、未 release、未 deploy。

## Upstream classification

| Upstream commit | Classification | Panel 处理 |
|---|---|---|
| `458e5e144bb9422a270c7df30e7b36d206839fa2` | `direct-port` | 以 `53ca3b7` 移植 Plugin Store grid/header/badge wrapping |
| `310fbff060006694a6a827beec4d92e361fd0a0a` | `direct-port` | 以 `c531596` 移植 Provider base URL responsive ellipsis |

两项均只触碰 SCSS module，不改变 route、Management API、provider data shape、plugin capability gate、完整 usage statistics 或 `management.html` release contract。

## 验证

以下检查均在 exact head `c531596` 通过：

- [x] `npm run check:lts`
- [x] `npm run validate:lts`
- [x] `npm run smoke:lts`
- [x] `npm run smoke:lts:core -- --no-write-smoke`
- [x] `git diff origin/main...HEAD --check`

`npm ci` 报告现有 lockfile 依赖存在 14 个 high severity audit findings；本 PR 未修改依赖或 lockfile，也未运行破坏性 `npm audit fix --force`。

## LTS 边界

- `/usage`、usage import/export、request events、pricing 和 provider usage chain：未改动。
- CPA-Core-LTS Management API compatibility：未改动；real Core smoke 已通过。
- Plugin capability gate：未改动。
- Release asset/workflow：未改动。
- 未执行 release、artifact 发布、部署或外部 runtime 更新。
