### PR TITLE
fix(api): 适配可读错误信息与 ClaudeAPI gateway 更新

### DIFF
--- a/src/features/providers/claudeApi.ts
+++ b/src/features/providers/claudeApi.ts
@@ -1,7 +1,8 @@
 import type { ProviderKeyConfig } from '@/types';
 
 export const CLAUDE_API_DISPLAY_NAME = 'ClaudeAPI';
-export const CLAUDE_API_BASE_URL = 'https://gw.claudeapi.com';
+export const CLAUDE_API_BASE_URL = 'https://gw.apito.ai';
+export const CLAUDE_API_LEGACY_BASE_URL = 'https://gw.claudeapi.com';
 
 const normalizeBaseUrl = (value: string | undefined | null): string =>
   String(value ?? '')
@@ -13,5 +14,8 @@ export const isClaudeApiProvider = (
   config: ProviderKeyConfig | undefined | null
 ): boolean => {
   if (!config) return false;
-  return normalizeBaseUrl(config.baseUrl) === normalizeBaseUrl(CLAUDE_API_BASE_URL);
+  const baseUrl = normalizeBaseUrl(config.baseUrl);
+  return [CLAUDE_API_BASE_URL, CLAUDE_API_LEGACY_BASE_URL].some(
+    (candidate) => baseUrl === normalizeBaseUrl(candidate)
+  );
 };

--- a/src/features/providers/providerIntegrity.test.mjs
+++ b/src/features/providers/providerIntegrity.test.mjs
@@ -11,16 +11,25 @@ const vite = await createServer({
   server: { middlewareMode: true },
 });
 
-const [transformers, providers, adapters, code0, fennoAI, qiniuCloud, sponsorDefinitions] =
-  await Promise.all([
-    vite.ssrLoadModule('/src/services/api/transformers.ts'),
-    vite.ssrLoadModule('/src/services/api/providers.ts'),
-    vite.ssrLoadModule('/src/features/providers/adapters.ts'),
-    vite.ssrLoadModule('/src/features/providers/code0.ts'),
-    vite.ssrLoadModule('/src/features/providers/fennoAI.ts'),
-    vite.ssrLoadModule('/src/features/providers/qiniuCloud.ts'),
-    vite.ssrLoadModule('/src/features/providers/sponsorDefinitions.ts'),
-  ]);
+const [
+  transformers,
+  providers,
+  adapters,
+  code0,
+  fennoAI,
+  qiniuCloud,
+  sponsorDefinitions,
+  claudeApi,
+] = await Promise.all([
+  vite.ssrLoadModule('/src/services/api/transformers.ts'),
+  vite.ssrLoadModule('/src/services/api/providers.ts'),
+  vite.ssrLoadModule('/src/features/providers/adapters.ts'),
+  vite.ssrLoadModule('/src/features/providers/code0.ts'),
+  vite.ssrLoadModule('/src/features/providers/fennoAI.ts'),
+  vite.ssrLoadModule('/src/features/providers/qiniuCloud.ts'),
+  vite.ssrLoadModule('/src/features/providers/sponsorDefinitions.ts'),
+  vite.ssrLoadModule('/src/features/providers/claudeApi.ts'),
+]);
 
 test.after(async () => {
   await vite.close();
@@ -96,4 +105,19 @@ test('deletes sponsor OpenAI entries by unique descending source index', () => {
   };
 
   assert.deepEqual(sponsorDefinitions.getSponsorOpenAIDeleteIndices(raw), [5, 2]);
+});
+
+test('recognizes the current and legacy ClaudeAPI gateways without affiliate metadata', () => {
+  assert.equal(claudeApi.CLAUDE_API_BASE_URL, 'https://gw.apito.ai');
+  assert.equal(claudeApi.CLAUDE_API_LEGACY_BASE_URL, 'https://gw.claudeapi.com');
+  assert.equal(claudeApi.isClaudeApiProvider({ baseUrl: 'https://gw.apito.ai/' }), true);
+  assert.equal(claudeApi.isClaudeApiProvider({ baseUrl: 'HTTPS://GW.CLAUDEAPI.COM' }), true);
+  assert.equal(
+    claudeApi.isClaudeApiProvider({ baseUrl: 'https://custom-claude.example.test' }),
+    false
+  );
+  assert.equal(
+    Object.keys(claudeApi).some((key) => key.toLowerCase().includes('affiliate')),
+    false
+  );
 });

--- a/src/services/api/apiError.ts
+++ b/src/services/api/apiError.ts
@@ -1,0 +1,40 @@
+import { isRecord } from '@/utils/helpers';
+
+export interface ParsedApiErrorResponse {
+  message: string;
+  apiCode?: string;
+}
+
+const readString = (value: unknown): string =>
+  typeof value === 'string' ? value.trim() : '';
+
+/**
+ * Parse the Management API's error envelope.
+ *
+ * Newer endpoints use `error` as a stable machine-readable code and `message`
+ * as the human-readable detail. Older endpoints may put the only useful text
+ * directly in `error`, so that remains a fallback.
+ */
+export const parseApiErrorResponse = (
+  responseData: unknown,
+  fallbackMessage: string
+): ParsedApiErrorResponse => {
+  if (!isRecord(responseData)) {
+    return {
+      message: readString(responseData) || readString(fallbackMessage) || 'Request failed',
+    };
+  }
+
+  const errorValue = responseData.error;
+  const errorRecord = isRecord(errorValue) ? errorValue : null;
+  const stringError = readString(errorValue);
+  const apiCode = stringError || readString(errorRecord?.code) || undefined;
+  const message =
+    readString(responseData.message) ||
+    readString(errorRecord?.message) ||
+    stringError ||
+    readString(fallbackMessage) ||
+    'Request failed';
+
+  return { message, apiCode };
+};

--- a/src/services/api/client.test.mjs
+++ b/src/services/api/client.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { AxiosError } from 'axios';
 import { createServer } from 'vite';
 
 const originalWindow = globalThis.window;
@@ -11,7 +12,19 @@ const vite = await createServer({
   server: { middlewareMode: true },
 });
 
-const { apiClient } = await vite.ssrLoadModule('/src/services/api/client.ts');
+const [{ apiClient }, { parseApiErrorResponse }] = await Promise.all([
+  vite.ssrLoadModule('/src/services/api/client.ts'),
+  vite.ssrLoadModule('/src/services/api/apiError.ts'),
+]);
+
+const unauthorizedError = (config, data) =>
+  new AxiosError('Request failed with status code 401', 'ERR_BAD_REQUEST', config, null, {
+    data,
+    status: 401,
+    statusText: 'Unauthorized',
+    headers: {},
+    config,
+  });
 
 test.after(async () => {
   apiClient.clearConfig();
@@ -53,4 +66,103 @@ test('binds connection details when the request is created', async () => {
   assert.equal(capturedConfig.baseURL, 'https://old-core.example.test/v0/management');
   assert.equal(capturedConfig.headers.get('Authorization'), 'Bearer old-management-key');
   assert.equal(capturedConfig.__cpaConnectionGeneration, initialGeneration);
+});
+
+test('prefers a human-readable Management API message and preserves the stable code', () => {
+  assert.deepEqual(
+    parseApiErrorResponse(
+      {
+        error: 'plugin_install_failed',
+        message: 'download plugin archive: 404 Not Found',
+      },
+      'Request failed with status code 502'
+    ),
+    {
+      message: 'download plugin archive: 404 Not Found',
+      apiCode: 'plugin_install_failed',
+    }
+  );
+  assert.deepEqual(parseApiErrorResponse({ error: 'invalid body' }, 'Bad Request'), {
+    message: 'invalid body',
+    apiCode: 'invalid body',
+  });
+  assert.deepEqual(
+    parseApiErrorResponse(
+      { error: { code: 'invalid_config', message: 'plugins-dir is invalid' } },
+      'Bad Request'
+    ),
+    {
+      message: 'plugins-dir is invalid',
+      apiCode: 'invalid_config',
+    }
+  );
+  assert.deepEqual(parseApiErrorResponse('upstream unavailable', 'Network Error'), {
+    message: 'upstream unavailable',
+  });
+  assert.deepEqual(parseApiErrorResponse({ error: null }, 'Network Error'), {
+    message: 'Network Error',
+    apiCode: undefined,
+  });
+});
+
+test('a stale 401 keeps its parsed error but cannot log out the current connection', async () => {
+  let releaseStaleRequest;
+  let unauthorizedEvents = 0;
+  const onUnauthorized = () => {
+    unauthorizedEvents += 1;
+  };
+  window.addEventListener('unauthorized', onUnauthorized);
+
+  try {
+    apiClient.setConfig({
+      apiBase: 'https://old-core.example.test',
+      managementKey: 'old-management-key',
+    });
+    const staleRequest = apiClient.get('/stale-401', {
+      adapter: (config) =>
+        new Promise((_, reject) => {
+          releaseStaleRequest = () =>
+            reject(
+              unauthorizedError(config, {
+                error: 'stale_unauthorized',
+                message: 'old connection expired',
+              })
+            );
+        }),
+    });
+
+    apiClient.setConfig({
+      apiBase: 'https://current-core.example.test',
+      managementKey: 'current-management-key',
+    });
+    assert.equal(typeof releaseStaleRequest, 'function');
+    releaseStaleRequest();
+
+    await assert.rejects(staleRequest, (error) => {
+      assert.equal(error.message, 'old connection expired');
+      assert.equal(error.status, 401);
+      assert.equal(error.apiCode, 'stale_unauthorized');
+      return true;
+    });
+    assert.equal(unauthorizedEvents, 0);
+
+    await assert.rejects(
+      apiClient.get('/current-401', {
+        adapter: async (config) => {
+          throw unauthorizedError(config, {
+            error: 'unauthorized',
+            message: 'current connection expired',
+          });
+        },
+      }),
+      (error) => {
+        assert.equal(error.message, 'current connection expired');
+        assert.equal(error.apiCode, 'unauthorized');
+        return true;
+      }
+    );
+    assert.equal(unauthorizedEvents, 1);
+  } finally {
+    window.removeEventListener('unauthorized', onUnauthorized);
+  }
 });

--- a/src/services/api/client.ts
+++ b/src/services/api/client.ts
@@ -16,8 +16,8 @@ import {
   VERSION_HEADER_KEYS
 } from '@/utils/constants';
 import { computeApiUrl } from '@/utils/connection';
-import { isRecord } from '@/utils/helpers';
 import type { ServerRuntimeKind } from '@/types';
+import { parseApiErrorResponse } from './apiError';
 
 type ConnectionScopedRequestConfig = AxiosRequestConfig & {
   __cpaConnectionGeneration?: number;
@@ -202,20 +202,12 @@ class ApiClient {
   private handleError(error: unknown): ApiError {
     if (axios.isAxiosError(error)) {
       const responseData: unknown = error.response?.data;
-      const responseRecord = isRecord(responseData) ? responseData : null;
-      const errorValue = responseRecord?.error;
-      const message =
-        typeof errorValue === 'string'
-          ? errorValue
-          : isRecord(errorValue) && typeof errorValue.message === 'string'
-            ? errorValue.message
-            : typeof responseRecord?.message === 'string'
-              ? responseRecord.message
-              : error.message || 'Request failed';
-      const apiError = new Error(message) as ApiError;
+      const parsedError = parseApiErrorResponse(responseData, error.message);
+      const apiError = new Error(parsedError.message) as ApiError;
       apiError.name = 'ApiError';
       apiError.status = error.response?.status;
       apiError.code = error.code;
+      apiError.apiCode = parsedError.apiCode;
       apiError.details = responseData;
       apiError.data = responseData;
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -30,7 +30,10 @@ export interface ServerVersion {
 // API 错误
 export type ApiError = Error & {
   status?: number;
+  /** Axios/network error code, such as ERR_NETWORK. */
   code?: string;
+  /** Machine-readable error code returned by the Management API. */
+  apiCode?: string;
   details?: unknown;
   data?: unknown;
 };


### PR DESCRIPTION
## 结果

适配移植 upstream 最近 7 天内的 Management API error parsing 与 ClaudeAPI gateway 更新：Panel 优先展示服务端 human-readable `message`，同时把稳定机器码保存在 `apiCode`；ClaudeAPI 默认 gateway 更新为 `gw.apito.ai`，旧 `gw.claudeapi.com` 继续被识别。LTS 的 connection-generation 401 隔离与 commercial-neutral 边界均保留。

当前仅为已推送 PR；尚未合入 `main`，未 tag、未 release、未 deploy。

## Upstream classification

| Upstream commit | Classification | LTS adaptation |
|---|---|---|
| `e677a68c4d35eee7082929837b4cd46a3fa0cb36` | `adapt-port` | 优先 response `message`、保留 machine-readable `apiCode`；继续阻止旧连接的 delayed 401 登出当前连接 |
| `b24f3069be19cb94a7a42efeadef3a0d8b411260` | `adapt-port` | 新 URL 作为 primary、旧 URL 作为 legacy；未移植 affiliate/registration metadata |

## 变更与兼容性

- 新增 `parseApiErrorResponse`，兼容 modern `{error: code, message}`、legacy string error、nested error object 与 text response。
- `ApiError.code` 继续表示 Axios/network code；新增 `ApiError.apiCode` 表示 Management API machine code，避免语义混用。
- `unauthorized` 事件仍只由当前 connection generation 的 401 触发；stale 401 仍返回自身错误，但不会登出新连接。
- ClaudeAPI provider detection 接受 primary/legacy gateway 的大小写与尾斜杠差异。
- 测试明确验证 provider module 不导出 affiliate metadata；LTS guard 也确认仓库没有禁止 marker。

## 验证

以下检查均在 exact head `ff2d9053035814e630beb0ee7d4d72330ea63f56` 通过：

- [x] `npm run test:api-client`
- [x] `npm run test:provider-integrity`
- [x] `npm run check:lts`
- [x] `npm run validate:lts`
- [x] `npm run smoke:lts`
- [x] `npm run smoke:lts:core -- --no-write-smoke`
- [x] `git diff HEAD^..HEAD --check`

首轮 `npm run check:lts` 曾因 regression test 写出了被 guard 禁止的完整 promotion marker 而失败；产品代码从未引入该 metadata。测试已改为枚举 module exports 的泛化检查，随后 targeted、contract、full validation 与两类 smoke 全部通过。

## LTS 边界

- 完整 usage statistics 与 CPA-Core-LTS usage API：未改动。
- Home runtime detection/log payload、Codex identity-confuse、auth-file writes：未删除或弱化。
- Provider custom endpoints/unknown fields：未改动。
- `management.html` release asset/workflow：未改动。
- 未执行 release、artifact 发布、部署或外部 runtime 更新。
