### PR TITLE
fix(usage): apply GPT-5.6 Terra and Luna price cuts

### DIFF
--- a/src/utils/usage/pricing/catalog.ts
+++ b/src/utils/usage/pricing/catalog.ts
@@ -1,12 +1,12 @@
 /** Official provider catalog data is kept separate from the pricing engine and UI. */
 export const PRICE_CURRENCY = 'USD' as const;
-export const OPENAI_CATALOG_AS_OF = '2026-07-20';
+export const OPENAI_CATALOG_AS_OF = '2026-07-31';
 export const ZAI_CATALOG_AS_OF = '2026-07-22';
 export const KIMI_CATALOG_AS_OF = '2026-07-28';
 export const XAI_CATALOG_AS_OF = '2026-07-23';
 export const CODEX_SPARK_CATALOG_AS_OF = '2026-07-25';
 export const ANTHROPIC_CATALOG_AS_OF = '2026-07-26';
-export const PRICE_CATALOG_AS_OF = ANTHROPIC_CATALOG_AS_OF;
+export const PRICE_CATALOG_AS_OF = OPENAI_CATALOG_AS_OF;
 export const PRICE_CATALOG_VERSION = `api-${PRICE_CATALOG_AS_OF}`;
 export const OPENAI_PRICING_SOURCE_URL = 'https://developers.openai.com/api/docs/pricing';
 export const ZAI_PRICING_SOURCE_URL = 'https://docs.z.ai/guides/overview/pricing';
@@ -106,8 +106,8 @@ export const PRICE_CATALOG: readonly PriceCatalogEntry[] = [
     aliases: [],
     currency: 'USD',
     standard: {
-      short: rateCard(2.5, 0.25, 3.125, 15),
-      long: longCard(rateCard(5, 0.5, 6.25, 22.5)),
+      short: rateCard(2, 0.2, 2.5, 12),
+      long: longCard(rateCard(4, 0.4, 5, 18)),
     },
     fast: { multiplier: 2, longSupported: false },
     sourceUrl: OPENAI_PRICING_SOURCE_URL,
@@ -118,7 +118,10 @@ export const PRICE_CATALOG: readonly PriceCatalogEntry[] = [
     canonicalModel: 'gpt-5.6-luna',
     aliases: [],
     currency: 'USD',
-    standard: { short: rateCard(1, 0.1, 1.25, 6), long: longCard(rateCard(2, 0.2, 2.5, 9)) },
+    standard: {
+      short: rateCard(0.2, 0.02, 0.25, 1.2),
+      long: longCard(rateCard(0.4, 0.04, 0.5, 1.8)),
+    },
     fast: { multiplier: 2, longSupported: false },
     sourceUrl: OPENAI_PRICING_SOURCE_URL,
     pricingNotesUrl: modelPricingNotesUrl('gpt-5.6-luna'),

--- a/src/utils/usage/pricing/index.test.mjs
+++ b/src/utils/usage/pricing/index.test.mjs
@@ -27,7 +27,7 @@ const approx = (actual, expected) =>
 
 test('catalog is versioned, self-describing, exact, and keeps provider rate boundaries explicit', () => {
   const sol = pricing.findCatalogEntry('gpt-5.6-sol');
-  assert.equal(pricing.PRICE_CATALOG_AS_OF, '2026-07-26');
+  assert.equal(pricing.PRICE_CATALOG_AS_OF, '2026-07-31');
   assert.equal(sol.currency, 'USD');
   assert.deepEqual(sol.aliases, ['gpt-5.6']);
   assert.equal(sol.sourceUrl, 'https://developers.openai.com/api/docs/pricing');
@@ -36,6 +36,34 @@ test('catalog is versioned, self-describing, exact, and keeps provider rate boun
   assert.equal(sol.standard.long.appliesTo, 'entireRequest');
   assert.equal(sol.fast.multiplier, 2);
   assert.equal(sol.fast.longSupported, false);
+  const terra = pricing.findCatalogEntry('gpt-5.6-terra');
+  assert.deepEqual(terra.standard.short, {
+    input: 2,
+    cachedInput: 0.2,
+    cacheWrite: 2.5,
+    output: 12,
+  });
+  assert.deepEqual(terra.standard.long.rates, {
+    input: 4,
+    cachedInput: 0.4,
+    cacheWrite: 5,
+    output: 18,
+  });
+  assert.equal(terra.asOf, '2026-07-31');
+  const luna = pricing.findCatalogEntry('gpt-5.6-luna');
+  assert.deepEqual(luna.standard.short, {
+    input: 0.2,
+    cachedInput: 0.02,
+    cacheWrite: 0.25,
+    output: 1.2,
+  });
+  assert.deepEqual(luna.standard.long.rates, {
+    input: 0.4,
+    cachedInput: 0.04,
+    cacheWrite: 0.5,
+    output: 1.8,
+  });
+  assert.equal(luna.asOf, '2026-07-31');
   const gpt55 = pricing.findCatalogEntry('gpt-5.5');
   assert.equal(gpt55.standard.long.basis, 'inputTokens');
   assert.equal(gpt55.standard.long.appliesTo, 'entireRequest');
@@ -417,7 +445,7 @@ test('the full input_tokens count switches GPT-5.5 at 271999, 272000, and 272001
     tier()
   );
   assert.equal(gpt56.contextBand, 'long');
-  assert.equal(gpt56.rates.input, 5);
+  assert.equal(gpt56.rates.input, 4);
 });
 
 test('GLM-5.2 keeps official Standard rates and explicit free cache write', () => {


### PR DESCRIPTION
## 结果

按 2026-07-31 生效的 GPT-5.6 定价调整更新 Panel LTS 本地 pricing catalog：`gpt-5.6-terra` 在原价基础上乘 `0.8`，`gpt-5.6-luna` 在原价基础上乘 `0.2`，并保留 `gpt-5.6-sol` 与既有快/慢速语义不变。

当前仅提交代码和测试；不创建 tag/Release、不发布 `management.html`、不部署运行时。

## 变更

- 更新 `src/utils/usage/pricing/catalog.ts` 中 Terra/Luna 的 input、cached input、output 与 cache write 价格。
- 将对应 catalog source date 更新为 `2026-07-31`。
- 扩充 pricing contract tests，精确断言两个模型的倍率和完整价格字段。
- 未修改 Core Management API、usage import/export、provider mapping、package 或 lockfile。

## 验证

以下检查在 exact head `dbcecb3d22b0eb1a40eb88c753cbbc8f313c92f5` 通过：

- [x] `npm run validate:lts`
- [x] pricing tests `22/22`
- [x] `type-check`
- [x] `lint`
- [x] production build
- [x] `git diff --check`

## 边界与回滚

- 缺失价格仍按 LTS fail-closed 语义处理，不会显示为免费或零成本。
- 本 PR 与 upstream selective-port、360-day analytics WIP 独立。
- 回滚只需回退本提交，不涉及配置或数据迁移。
