### PR TITLE
fix(lts): 按 selective-port 吸收 upstream v1.21.4 正确性修复

### DIFF
--- a/docs/lts/sync-runbook.md
+++ b/docs/lts/sync-runbook.md
@@ -107,7 +107,89 @@ Every accepted PR passed `npm run check:lts`, `npm run validate:lts`, `npm run s
 | `0f87214e262a683d2b3ea291b5a16ee4469d22d7` | `defer` | Dashboard series review | Animation and chart responsiveness changes have no safe standalone target before the dashboard rewrite is accepted. |
 | `1708314bc7a27e0ad9ef86b083e28e4e00aceeb1` | `defer` | Dashboard series review | Ambient positioning and wash effects are follow-up CSS for the deferred dashboard architecture. |
 
-`upstream/dev` has one additional watchlist commit, `51b034dd914719c3bd6b5ab0eb64bc8b103ca0d4`, which adds `applicableAvailableCount` to shared Codex quota structures. It remains `defer`: it is not on `upstream/main`, and CPA-Panel-LTS owns additional Codex quota/reset-credit classification in `src/lts/codexQuota/`. Reassess only after the upstream behavior stabilizes and can be compared against the sidecar's selection and availability semantics.
+The earlier `upstream/dev` watchlist commit `51b034dd914719c3bd6b5ab0eb64bc8b103ca0d4` is now on `upstream/main` and is reassessed in the next snapshot. It remains `defer`: CPA-Panel-LTS owns additional Codex quota/reset-credit classification in `src/lts/codexQuota/`, so its selection and availability semantics must be compared with the sidecar before porting.
+
+## Audited seven-day intake snapshot (2026-08-03)
+
+Refs were fetched after Core v7.2.116, Panel pricing, and the 360-day Codex analytics PRs were merged:
+
+- `origin/main`: `a60570ca8ec9d3d5a1184491cf9b7c01e76e4e72`
+- previous audited boundary: `1708314bc7a27e0ad9ef86b083e28e4e00aceeb1` (`v1.20.0`)
+- `upstream/main`: `30478c539c1f06649ac78deebeff6cfc227bbe22` (`v1.21.4`)
+- canonical first-parent non-merge commits reviewed: 56
+- raw upstream diff: 180 files, 18,426 insertions, 8,505 deletions
+- decisions: 1 `direct-port`, 11 `adapt-port`, 6 `already-equivalent`, 1 `reject`, 37 `defer`
+
+The accepted subset is deliberately architecture-neutral: auth-file boundary normalization and stale-request/cache guards, xAI/Kimi quota parser correctness, reset/refresh exclusion, and the standalone Sheet focus fix. The AuthFiles/Vault rewrite, WRR/excluded-model/Interactions contracts, and the quota redesign/timeline series remain deferred. Full usage statistics, the old LTS quota host, npm/package-lock, all downstream Codex sidecars, and `management.html` remain unchanged.
+
+Dependency chains reviewed as units rather than isolated hunks:
+
+- AuthFiles: `dbe7094 -> 20c0cb8 -> b9c3fbb -> cc13476 -> 0a181ba -> 29b1b9b`
+- WRR: `8faaa39 -> 90971e8`
+- Excluded models: `afd7da0 -> 20bb855 -> 4abd41f -> 826ea3c`
+- Quota redesign: `572da18 -> 9ecd89b -> 54af5fb -> 46ffeba -> 1705246 -> ... -> 30478c5`
+
+| Upstream commit | Classification | LTS evidence and decision |
+|---|---|---|
+| `51b034dd914719c3bd6b5ab0eb64bc8b103ca0d4` | `defer` | Codex `applicableAvailableCount` 与 LTS `src/lts/codexQuota/` 的 reset-credit 分类不等价；待 sidecar/API 一起审。 |
+| `22cf825d071ac9cc835fe422dae87acd2fded3a2` | `defer` | 共享 motion hooks 依赖未接纳的 Dashboard 系列，当前 LTS 没有直接目标。 |
+| `b62dbefda80f81fabaff189f931ce77583efab59` | `defer` | QuotaCard/AuthFiles 样式与错误 resolver 大重排依赖新 quota 架构，不能覆盖 LTS 宿主。 |
+| `dbe7094e8cb3152e9f9422fb942fd5b0107af98d` | `adapt-port` | 已在 `authFiles.ts` 保留 raw 字段并归一化 camelCase、recent requests、计数和 Blob download；Node regression 覆盖。 |
+| `20c0cb865e5572757ae01fa4e3d5ca7d0af16389` | `adapt-port` | 已适配到旧页面 hooks：后台刷新、stale list request、batch download、model/quota cache invalidation；未引入新 AuthFiles 架构。 |
+| `b9c3fbbb77fc686251290d5d7d5434a038460857` | `defer` | AuthFiles card/quota/sheet/batch componentization 是大结构迁移，会穿过现有 LTS quota/OAuth 集成。 |
+| `cc13476844e4328cf1f1a973d548e019ccd371ff` | `defer` | Vault header、pulse、provider tabs 重建并删除旧页面；需独立产品/浏览器验收。 |
+| `0a181ba6616ca67a17f42659f0816f706a5c39f5` | `defer` | 依赖未接纳的 Vault/Pulse 结构及 i18n 删除，不能单独移植。 |
+| `29b1b9bb4812a8e3b475f34794f736013bd73947` | `defer` | 仅是未接纳 VaultHeader 的后续整理，当前 LTS 无对应组件。 |
+| `3c8eba30274b315e702ac76108f40ae378027577` | `adapt-port` | 已统一 `isProblemAuthFile`：disabled 独立，error/unavailable/非健康 message 才进入问题筛选和批量删除；有 Node regression。 |
+| `966a2918d53e9bb272e61b77ceef8c85c8eea69a` | `adapt-port` | 已使 auth-file 上传/删除/字段保存同步失效 model 与 generation-protected quota caches；有 Node regression。 |
+| `840df32f16a6b67da455f1676494da31d031f16d` | `adapt-port` | 已给 model modal 增加 request ID、全局/单文件 cache version 和 close invalidation，旧响应不能覆盖新 modal。 |
+| `b76037ac7cb4860926c25ff92eb2ef485f6cf938` | `adapt-port` | 已让只有最新 list request 清 loading/refreshing，mutation 失效时主动收口状态。 |
+| `c9636a3c543c564ca9b59fd5d9b3c22da1970969` | `adapt-port` | 已增加同步 `uploadPendingRef`，阻止 React 状态提交前的重复上传。 |
+| `6360b52d1827dfa647172d8aafcb6f195dbd01ac` | `already-equivalent` | 当前 `AuthFilesPage.module.scss` 已覆盖 header/action/pagination/quota 的 mobile wrapping；不复制新路径 CSS。 |
+| `9524cc7f32a3d227a71540e169b0a7b1545dbdc9` | `defer` | Codex Pro 20x badge/animation 依赖新 quota/AuthFiles 视觉架构，不是 correctness port。 |
+| `8faaa395346624258408b442a5d4923f3b0e1fc8` | `defer` | WRR strategy/credential weight 跨 Core schema、visual config 和写入并发，需跨仓库专项。 |
+| `90971e8f6a573e800dc8909c350285bf2f1c2396` | `defer` | 依赖 WRR Core contract 与新 AuthFiles UI，不能只接 weight 控件。 |
+| `530b585bd0b72448bc576e970b0f2c6f1f55df11` | `defer` | Interactions provider surface 需要当前 CPA-Core-LTS Management/API contract；本批次不新增 provider 产品面。 |
+| `fe93db0941de406c336d0db8a4a12f9ebd8959bd` | `already-equivalent` | LTS `CODEX_CONFIG.canResetQuota` 已按 total available reset credits 显示 reset action。 |
+| `6cda18a85235e7f047d8584d93480319c10e1942` | `defer` | 9524cc7 的视觉 follow-up，依赖未接纳 quota redesign。 |
+| `13a22da08224930fd50a07e4497540469764b988` | `defer` | 当前 LTS 无上游 `features/dashboard/.heroPeriod` 结构。 |
+| `afd7da059d9749773127163eb42236694ad801f8` | `defer` | LTS 已有不同的 OAuth excluded-model contract；新 per-auth/global rules 需与 Core 一起审。 |
+| `20bb8559d476efb5cc3707d68bb8c74ed2a79375` | `defer` | 依赖 afd7da0 的 excluded-model backend/UI contract。 |
+| `4abd41f947bccae528acba7a4be67c074a802aa9` | `defer` | 依赖前两段 excluded-model 新模块；不替换现有 OAuth excluded 页面。 |
+| `826ea3c0d0bdd6409a0a2703ada90faaf5aede2d` | `already-equivalent` | docs-only consolidation note，无运行时行为可移植。 |
+| `7345e99059f66810c921529b33d7d82d2946af89` | `already-equivalent` | test-only helper extraction；当前 LTS plan tier 行为无缺口，不为镜像 ancestry 新增代码。 |
+| `572da189bc4e8997efa09f3acaffad317dc79e4c` | `defer` | Provider quota data layer 大拆分与 LTS `quotaConfigs` + Codex sidecar 架构不同。 |
+| `9ecd89b1367e4494bcd672da40bb04e7fc0fd917` | `defer` | Typed JSX quota bodies 依赖 572da18，直接替换会破坏 LTS renderer/styles。 |
+| `54af5fb3e3cb1943cff8c93599d8963b4839a1ed` | `defer` | 新 quota feature shell 是未路由的大功能，需整体评估。 |
+| `46ffeba5ddd7f2dc846353b33909ed21ef14654e` | `defer` | 将 `/quota` 切到新 shell 并删除旧实现，会直接切断 LTS quota integration。 |
+| `1705246ed1ca68286c146adf08539ffa26d3db53` | `defer` | 新 quota shell 的 motion follow-up，不可独立。 |
+| `fb6d94788b77e75cd46bf3e4008dbba369413a22` | `reject` | 删除的 view-mode/too-many-files i18n 仍被 LTS `QuotaSection.tsx` 使用，移植会产生缺失文案。 |
+| `66d24c053c36998c1ffade24c7fb507e0eb6d306` | `adapt-port` | 已在旧 `QuotaSection` 阻止 reset 期间的单卡/全量 refresh 并禁用 refresh button。 |
+| `31afcffd99e486e46b2080b7465cbaf717ee1e1c` | `defer` | 上游修的是新 Antigravity countdown component；LTS 当前显示稳定 absolute reset timestamp，无同一 hook target。 |
+| `ea107fded08688eeb96c1269b036216d434eded1` | `defer` | Quota timeline/reset instant 是新 quota 架构的大功能。 |
+| `01ab01d388fdcd918cc4d16d75b922844027af2a` | `defer` | 仅是 timeline 的 5h window follow-up。 |
+| `ea0652c51cdf388651538b3e143da2afec8c6099` | `adapt-port` | 已在旧 xAI builder 原子选择 period type/start/end，避免 weekly 类型借用 monthly rollover；Node regression 覆盖。 |
+| `66d52992e8ead5ed0f442936d875a4932e715768` | `defer` | 依赖 timeline state model，旧 LTS 无对应 stale usage fill。 |
+| `f3713c53825b3e3ae6d0212b4dc82c444353520e` | `defer` | 新 QuotaPage pagination contract 与 LTS AuthFiles/Quota 分页不同。 |
+| `7c072c4ab4266453f526b56505335698ac87c122` | `defer` | AuthFiles identity/search 大改跨现有筛选、分页、quota 和 OAuth。 |
+| `8038469a2da13b7e3cc9fbd5a4aa3dc1ced0996a` | `defer` | QuotaTimeline empty state/zoom follow-up，无旧架构 target。 |
+| `b2bd48e58b8bc5d79e47e40b974a853112d38854` | `adapt-port` | 已在旧 Kimi builder 支持 singular/plural、`TIME_UNIT_*`、snake/camel unit 和 week；Node regression 覆盖。 |
+| `7976b16f6c2fb957a050c0593e571c59dc836f9b` | `defer` | LMU AI 同时带 provider、sponsor/affiliate surface，缺少 Core contract 且业务决策未授权。 |
+| `6394584b99d245a055f977acf1d2da2eab346302` | `defer` | disable-cooling 跨 Core auth mutation/schema，需跨仓库写入验收。 |
+| `648a3d4af4dced499e7f544a953a717b8d417605` | `direct-port` | 已原样移植 Sheet body scroll reset 与 `focus({preventScroll:true})`；不触及 protected seam。 |
+| `b1aefecf94b3ba0efe41463821fd56d44ee9e21e` | `defer` | 依赖未接纳的 ExcludedModelsPanel。 |
+| `285d9e6753111d30dfcf54d3c225119ade7ed3c1` | `defer` | Manual reset credit timeline 行为与 LTS Codex reset-credit sidecar 不同。 |
+| `ddabc99e24cc5fdc59d47ce4de9ef2811c939e89` | `defer` | shared minute clock/relative-time 绑定新 quota bodies；不为视觉增强重构全部旧 renderer。 |
+| `3eb9f3cc712983212a6d92520e6c1c7a2dc54d51` | `already-equivalent` | LTS Codex reset-credit expiry 已用 browser-local `Date`/`toLocaleString`。 |
+| `0272e9b455cb38343d835f83ba26c9f7b508e580` | `defer` | 所有 absolute dates 的 relative label 依赖新 QuotaResetLabel，不扩大本批次 UI 范围。 |
+| `c277ad353ca8d437de6ed04f5a1600f6a9414296` | `defer` | recovery highlight 依赖统一 resetSchedule contract，旧 LTS 无该抽象。 |
+| `001e1308cfa52d893a91ab73487ef7c1cdff64f6` | `defer` | soonest-recovery sort 依赖新 QuotaPage state。 |
+| `f50f9b0f643aacbbb3b699b8853e00a268387992` | `already-equivalent` | test-only Timeline prop，LTS 无 Timeline 运行时。 |
+| `afee40ec2310878833831ff70757e6e73a04a5f5` | `defer` | urgent-final-hour emphasis 依赖 recovery/timeline 系列。 |
+| `30478c539c1f06649ac78deebeff6cfc227bbe22` | `adapt-port` | 已在旧 Kimi rows 保留 concrete reset instant，并显示 absolute local time + relative hint；Node regression 覆盖。 |
+
+Accepted code was validated with the repository's npm/Node regression path, TypeScript checker, ESLint, LTS contract/build, mock browser smoke, and the read-only local Core smoke before merge. Publishing a tag, GitHub release, or `management.html` asset remains a separate explicitly authorized action.
+
 
 ## Maintenance rules
 

--- a/src/components/quota/QuotaSection.tsx
+++ b/src/components/quota/QuotaSection.tsx
@@ -177,9 +177,10 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
   const singleRefreshInFlightRef = useRef<Set<string>>(new Set());
 
   const handleRefresh = useCallback(() => {
+    if (resettingQuotaName !== null) return;
     pendingQuotaRefreshRef.current = true;
     void triggerHeaderRefresh();
-  }, []);
+  }, [resettingQuotaName]);
 
   useEffect(() => {
     const wasLoading = prevFilesLoadingRef.current;
@@ -347,7 +348,7 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
             size="sm"
             className={styles.refreshAllButton}
             onClick={handleRefresh}
-            disabled={disabled || isRefreshing}
+            disabled={disabled || isRefreshing || resettingQuotaName !== null}
             loading={isRefreshing}
             title={t('quota_management.refresh_all_credentials')}
             aria-label={t('quota_management.refresh_all_credentials')}
@@ -374,13 +375,13 @@ export function QuotaSection<TState extends QuotaStatusState, TData>({
               const showResetQuotaAction =
                 itemQuota !== undefined && Boolean(config.canResetQuota?.(itemQuota));
               const resetQuotaAction =
-                config.resetQuota && showResetQuotaAction ? (
-                  {
-                    disabled: !canUseQuotaAction || isResettingQuota,
-                    loading: isResettingQuota,
-                    onClick: () => resetQuotaForFile(item),
-                  }
-                ) : undefined;
+                config.resetQuota && showResetQuotaAction
+                  ? {
+                      disabled: !canUseQuotaAction || isResettingQuota,
+                      loading: isResettingQuota,
+                      onClick: () => resetQuotaForFile(item),
+                    }
+                  : undefined;
 
               return (
                 <QuotaCard

--- a/src/components/quota/quotaConfigs.ts
+++ b/src/components/quota/quotaConfigs.ts
@@ -1022,7 +1022,15 @@ const renderKimiItems = (
     const rowLabel = row.labelKey
       ? t(row.labelKey, (row.labelParams ?? {}) as Record<string, string | number>)
       : (row.label ?? '');
-    const resetLabel = formatKimiResetHint(t, row.resetHint);
+    const resetHint = formatKimiResetHint(t, row.resetHint);
+    const absoluteReset =
+      row.resetAtMs !== null && row.resetAtMs !== undefined
+        ? formatQuotaResetTime(new Date(row.resetAtMs).toISOString())
+        : '-';
+    const resetAtLabel =
+      absoluteReset !== '-' ? t('kimi_quota.reset_at', { time: absoluteReset }) : '';
+    const resetLabel =
+      resetAtLabel && resetHint ? `${resetAtLabel} · ${resetHint}` : resetAtLabel || resetHint;
 
     return h(
       'div',

--- a/src/components/ui/Sheet/Sheet.tsx
+++ b/src/components/ui/Sheet/Sheet.tsx
@@ -62,6 +62,7 @@ export function Sheet({
   const [isClosing, setIsClosing] = useState(false);
   const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const sheetRef = useRef<HTMLDivElement | null>(null);
+  const bodyRef = useRef<HTMLDivElement | null>(null);
   const closeBtnRef = useRef<HTMLButtonElement | null>(null);
   const previouslyFocusedRef = useRef<HTMLElement | null>(null);
 
@@ -146,8 +147,9 @@ export function Sheet({
     previouslyFocusedRef.current =
       document.activeElement instanceof HTMLElement ? document.activeElement : null;
     const t = window.setTimeout(() => {
+      if (bodyRef.current) bodyRef.current.scrollTop = 0;
       const first = getFocusableElements()[0];
-      (first ?? closeBtnRef.current ?? sheetRef.current)?.focus();
+      (first ?? closeBtnRef.current ?? sheetRef.current)?.focus({ preventScroll: true });
     }, 0);
     return () => window.clearTimeout(t);
   }, [getFocusableElements, open]);
@@ -247,7 +249,9 @@ export function Sheet({
             ) : null}
           </div>
         )}
-        <div className={styles.body}>{children}</div>
+        <div ref={bodyRef} className={styles.body}>
+          {children}
+        </div>
         {footer ? <div className={styles.footer}>{footer}</div> : null}
       </div>
     </div>

--- a/src/features/authFiles/cacheInvalidation.ts
+++ b/src/features/authFiles/cacheInvalidation.ts
@@ -1,0 +1,12 @@
+import { useQuotaStore } from '@/stores/useQuotaStore';
+
+type ModelsInvalidator = (names?: string[]) => void;
+
+/** Invalidate caches whose values depend on the underlying credential file. */
+export const invalidateAuthFileDerivedCaches = (
+  invalidateModels: ModelsInvalidator,
+  names?: string[]
+): void => {
+  invalidateModels(names);
+  useQuotaStore.getState().clearQuotaCache();
+};

--- a/src/features/authFiles/components/AuthFileCard.tsx
+++ b/src/features/authFiles/components/AuthFileCard.tsx
@@ -33,6 +33,7 @@ import {
   getThemeSurfaceIconBackground,
   getTypeColor,
   getTypeLabel,
+  hasAuthFileStatusWarning,
   isRuntimeOnlyAuthFile,
   isThemeSurfaceIconProvider,
   normalizeProviderKey,
@@ -43,8 +44,6 @@ import {
 import type { AuthFileStatusBarData } from '@/features/authFiles/hooks/useAuthFilesStatusBarCache';
 import { AuthFileQuotaSection } from '@/features/authFiles/components/AuthFileQuotaSection';
 import styles from '@/pages/AuthFilesPage.module.scss';
-
-const HEALTHY_STATUS_MESSAGES = new Set(['ok', 'healthy', 'ready', 'success', 'available']);
 
 export type AuthFileCardProps = {
   file: AuthFileItem;
@@ -135,8 +134,7 @@ export function AuthFileCard(props: AuthFileCardProps) {
     (authIndexKey && statusBarCache.get(authIndexKey)) ||
     statusBarDataFromRecentRequests(recentBuckets);
   const rawStatusMessage = getAuthFileStatusMessage(file);
-  const hasStatusWarning =
-    Boolean(rawStatusMessage) && !HEALTHY_STATUS_MESSAGES.has(rawStatusMessage.toLowerCase());
+  const hasStatusWarning = hasAuthFileStatusWarning(file);
 
   const priorityValue = parsePriorityValue(file.priority ?? file['priority']);
   const noteValue = typeof file.note === 'string' ? file.note.trim() : '';

--- a/src/features/authFiles/constants.ts
+++ b/src/features/authFiles/constants.ts
@@ -186,8 +186,25 @@ export const getAuthFileStatusMessage = (file: AuthFileItem): string => {
   return String(raw).trim();
 };
 
-export const hasAuthFileStatusMessage = (file: AuthFileItem): boolean =>
-  getAuthFileStatusMessage(file).length > 0;
+export const HEALTHY_AUTH_FILE_STATUS_MESSAGES = new Set([
+  'ok',
+  'healthy',
+  'ready',
+  'success',
+  'available',
+]);
+
+export const hasAuthFileStatusWarning = (file: AuthFileItem): boolean => {
+  const message = getAuthFileStatusMessage(file);
+  return Boolean(message) && !HEALTHY_AUTH_FILE_STATUS_MESSAGES.has(message.toLowerCase());
+};
+
+/** Disabled credentials are an operator choice, not a problem result. */
+export const isProblemAuthFile = (file: AuthFileItem): boolean => {
+  const status = typeof file.status === 'string' ? file.status.trim().toLowerCase() : '';
+  if (file.disabled === true || status === 'disabled') return false;
+  return file.unavailable === true || status === 'error' || hasAuthFileStatusWarning(file);
+};
 
 export const getTypeLabel = (t: TFunction, type: string): string => {
   const providerKey = normalizeProviderKey(type);

--- a/src/features/authFiles/hooks/useAuthFilesData.ts
+++ b/src/features/authFiles/hooks/useAuthFilesData.ts
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useRef, useState, type ChangeEvent, type RefObject } from 'react';
 import { useTranslation } from 'react-i18next';
 import { authFilesApi } from '@/services/api';
-import { apiClient } from '@/services/api/client';
 import { useNotificationStore } from '@/stores';
 import type { AuthFileItem } from '@/types';
 import { formatFileSize } from '@/utils/format';
@@ -9,7 +8,7 @@ import { MAX_AUTH_FILE_SIZE } from '@/utils/constants';
 import { downloadBlob } from '@/utils/download';
 import {
   getTypeLabel,
-  hasAuthFileStatusMessage,
+  isProblemAuthFile,
   isRuntimeOnlyAuthFile,
   normalizeProviderKey,
 } from '@/features/authFiles/constants';
@@ -23,11 +22,20 @@ type DeleteAllOptions = {
   onResetDisabledOnly: () => void;
 };
 
+export type LoadFilesOptions = {
+  background?: boolean;
+};
+
+export type UseAuthFilesDataOptions = {
+  onFilesMutated?: (names?: string[]) => void;
+};
+
 export type UseAuthFilesDataResult = {
   files: AuthFileItem[];
   selectedFiles: Set<string>;
   selectionCount: number;
   loading: boolean;
+  refreshing: boolean;
   error: string;
   uploading: boolean;
   deleting: string | null;
@@ -35,7 +43,7 @@ export type UseAuthFilesDataResult = {
   statusUpdating: Record<string, boolean>;
   batchStatusUpdating: boolean;
   fileInputRef: RefObject<HTMLInputElement | null>;
-  loadFiles: () => Promise<void>;
+  loadFiles: (options?: LoadFilesOptions) => Promise<void>;
   handleUploadClick: () => void;
   handleFileChange: (event: ChangeEvent<HTMLInputElement>) => Promise<void>;
   handleDelete: (name: string) => void;
@@ -51,12 +59,14 @@ export type UseAuthFilesDataResult = {
   batchDelete: (names: string[]) => void;
 };
 
-export function useAuthFilesData(): UseAuthFilesDataResult {
+export function useAuthFilesData(options?: UseAuthFilesDataOptions): UseAuthFilesDataResult {
   const { t } = useTranslation();
   const { showNotification, showConfirmation } = useNotificationStore();
+  const onFilesMutated = options?.onFilesMutated;
 
   const [files, setFiles] = useState<AuthFileItem[]>([]);
   const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState('');
   const [uploading, setUploading] = useState(false);
   const [deleting, setDeleting] = useState<string | null>(null);
@@ -66,7 +76,18 @@ export function useAuthFilesData(): UseAuthFilesDataResult {
   const [selectedFiles, setSelectedFiles] = useState<Set<string>>(new Set());
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const uploadPendingRef = useRef(false);
   const batchStatusPendingRef = useRef(false);
+  const loadRequestIdRef = useRef(0);
+  const invalidateInFlightLoads = useCallback(() => {
+    loadRequestIdRef.current += 1;
+    setLoading(false);
+    setRefreshing(false);
+  }, []);
+  const onFilesMutatedRef = useRef(onFilesMutated);
+  useEffect(() => {
+    onFilesMutatedRef.current = onFilesMutated;
+  }, [onFilesMutated]);
   const selectionCount = selectedFiles.size;
   const toggleSelect = useCallback((name: string) => {
     setSelectedFiles((prev) => {
@@ -115,32 +136,31 @@ export function useAuthFilesData(): UseAuthFilesDataResult {
     setSelectedFiles(new Set());
   }, []);
 
-  const applyDeletedFiles = useCallback((names: string[]) => {
-    const deletedNames = Array.from(
-      new Set(
-        names
-          .map((name) => name.trim())
-          .filter(Boolean)
-      )
-    );
-    if (deletedNames.length === 0) return;
+  const applyDeletedFiles = useCallback(
+    (names: string[]) => {
+      const deletedNames = Array.from(new Set(names.map((name) => name.trim()).filter(Boolean)));
+      if (deletedNames.length === 0) return;
 
-    const deletedSet = new Set(deletedNames);
-    setFiles((prev) => prev.filter((file) => !deletedSet.has(file.name)));
-    setSelectedFiles((prev) => {
-      if (prev.size === 0) return prev;
-      let changed = false;
-      const next = new Set<string>();
-      prev.forEach((name) => {
-        if (deletedSet.has(name)) {
-          changed = true;
-        } else {
-          next.add(name);
-        }
+      invalidateInFlightLoads();
+      onFilesMutatedRef.current?.(deletedNames);
+      const deletedSet = new Set(deletedNames);
+      setFiles((prev) => prev.filter((file) => !deletedSet.has(file.name)));
+      setSelectedFiles((prev) => {
+        if (prev.size === 0) return prev;
+        let changed = false;
+        const next = new Set<string>();
+        prev.forEach((name) => {
+          if (deletedSet.has(name)) {
+            changed = true;
+          } else {
+            next.add(name);
+          }
+        });
+        return changed ? next : prev;
       });
-      return changed ? next : prev;
-    });
-  }, []);
+    },
+    [invalidateInFlightLoads]
+  );
 
   useEffect(() => {
     if (selectedFiles.size === 0) return;
@@ -159,21 +179,39 @@ export function useAuthFilesData(): UseAuthFilesDataResult {
     });
   }, [files, selectedFiles.size]);
 
-  const loadFiles = useCallback(async () => {
-    setLoading(true);
-    setError('');
-    try {
-      const data = await authFilesApi.list();
-      setFiles(data?.files || []);
-    } catch (err: unknown) {
-      const errorMessage = err instanceof Error ? err.message : t('notification.refresh_failed');
-      setError(errorMessage);
-    } finally {
-      setLoading(false);
-    }
-  }, [t]);
+  const loadFiles = useCallback(
+    async (options?: LoadFilesOptions) => {
+      const background = options?.background === true;
+      const requestId = ++loadRequestIdRef.current;
+
+      if (background) {
+        setRefreshing(true);
+      } else {
+        setLoading(true);
+        setError('');
+      }
+
+      try {
+        const data = await authFilesApi.list();
+        if (requestId !== loadRequestIdRef.current) return;
+        setFiles(data?.files || []);
+        setError('');
+      } catch (err: unknown) {
+        if (requestId !== loadRequestIdRef.current) return;
+        const errorMessage = err instanceof Error ? err.message : t('notification.refresh_failed');
+        setError(errorMessage);
+      } finally {
+        if (requestId === loadRequestIdRef.current) {
+          setLoading(false);
+          setRefreshing(false);
+        }
+      }
+    },
+    [t]
+  );
 
   const handleUploadClick = useCallback(() => {
+    if (uploadPendingRef.current) return;
     fileInputRef.current?.click();
   }, []);
 
@@ -213,7 +251,12 @@ export function useAuthFilesData(): UseAuthFilesDataResult {
         event.target.value = '';
         return;
       }
+      if (uploadPendingRef.current) {
+        event.target.value = '';
+        return;
+      }
 
+      uploadPendingRef.current = true;
       setUploading(true);
       try {
         const result = await authFilesApi.uploadFiles(validFiles);
@@ -225,19 +268,19 @@ export function useAuthFilesData(): UseAuthFilesDataResult {
             `${t('auth_files.upload_success')}${suffix}`,
             result.failed.length ? 'warning' : 'success'
           );
-          await loadFiles();
+          onFilesMutatedRef.current?.(result.files.length > 0 ? result.files : undefined);
+          await loadFiles({ background: true });
         }
 
         if (result.failed.length > 0) {
-          const details = result.failed
-            .map((item) => `${item.name}: ${item.error}`)
-            .join('; ');
+          const details = result.failed.map((item) => `${item.name}: ${item.error}`).join('; ');
           showNotification(`${t('notification.upload_failed')}: ${details}`, 'error');
         }
       } catch (err: unknown) {
         const errorMessage = err instanceof Error ? err.message : 'Unknown error';
         showNotification(`${t('notification.upload_failed')}: ${errorMessage}`, 'error');
       } finally {
+        uploadPendingRef.current = false;
         setUploading(false);
         event.target.value = '';
       }
@@ -306,6 +349,8 @@ export function useAuthFilesData(): UseAuthFilesDataResult {
             if (!isFiltered && !isProblemOnly && !isDisabledOnly) {
               await authFilesApi.deleteAll();
               showNotification(t('auth_files.delete_all_success'), 'success');
+              invalidateInFlightLoads();
+              onFilesMutatedRef.current?.();
               setFiles((prev) => prev.filter((file) => isRuntimeOnlyAuthFile(file)));
               deselectAll();
             } else {
@@ -317,7 +362,7 @@ export function useAuthFilesData(): UseAuthFilesDataResult {
                 ) {
                   return false;
                 }
-                if (isProblemOnly && !hasAuthFileStatusMessage(file)) return false;
+                if (isProblemOnly && !isProblemAuthFile(file)) return false;
                 if (isDisabledOnly && file.disabled !== true) return false;
                 return true;
               });
@@ -336,9 +381,7 @@ export function useAuthFilesData(): UseAuthFilesDataResult {
                 return;
               }
 
-              const result = await authFilesApi.deleteFiles(
-                filesToDelete.map((file) => file.name)
-              );
+              const result = await authFilesApi.deleteFiles(filesToDelete.map((file) => file.name));
               const success = result.deleted;
               const failed = result.failed.length;
 
@@ -406,17 +449,21 @@ export function useAuthFilesData(): UseAuthFilesDataResult {
         },
       });
     },
-    [applyDeletedFiles, deselectAll, files, showConfirmation, showNotification, t]
+    [
+      applyDeletedFiles,
+      deselectAll,
+      files,
+      invalidateInFlightLoads,
+      showConfirmation,
+      showNotification,
+      t,
+    ]
   );
 
   const handleDownload = useCallback(
     async (name: string) => {
       try {
-        const response = await apiClient.getRaw(
-          `/auth-files/download?name=${encodeURIComponent(name)}`,
-          { responseType: 'blob' }
-        );
-        const blob = new Blob([response.data]);
+        const blob = await authFilesApi.download(name);
         downloadBlob({ filename: name, blob });
         showNotification(t('auth_files.download_success'), 'success');
       } catch (err: unknown) {
@@ -434,10 +481,12 @@ export function useAuthFilesData(): UseAuthFilesDataResult {
       const previousDisabled = item.disabled === true;
 
       setStatusUpdating((prev) => ({ ...prev, [name]: true }));
+      invalidateInFlightLoads();
       setFiles((prev) => prev.map((f) => (f.name === name ? { ...f, disabled: nextDisabled } : f)));
 
       try {
         const res = await authFilesApi.setStatus(name, nextDisabled);
+        invalidateInFlightLoads();
         setFiles((prev) =>
           prev.map((f) => (f.name === name ? { ...f, disabled: res.disabled } : f))
         );
@@ -462,7 +511,7 @@ export function useAuthFilesData(): UseAuthFilesDataResult {
         });
       }
     },
-    [showNotification, t]
+    [invalidateInFlightLoads, showNotification, t]
   );
 
   const batchSetStatus = useCallback(
@@ -486,6 +535,7 @@ export function useAuthFilesData(): UseAuthFilesDataResult {
 
       batchStatusPendingRef.current = true;
       setBatchStatusUpdating(true);
+      invalidateInFlightLoads();
       setStatusUpdating((prev) => {
         const next = { ...prev };
         targetNameList.forEach((name) => {
@@ -503,6 +553,7 @@ export function useAuthFilesData(): UseAuthFilesDataResult {
         const results = await Promise.allSettled(
           targetNameList.map((name) => authFilesApi.setStatus(name, nextDisabled))
         );
+        invalidateInFlightLoads();
 
         let successCount = 0;
         let failCount = 0;
@@ -533,7 +584,10 @@ export function useAuthFilesData(): UseAuthFilesDataResult {
         );
 
         if (failCount === 0) {
-          showNotification(t('auth_files.batch_status_success', { count: successCount }), 'success');
+          showNotification(
+            t('auth_files.batch_status_success', { count: successCount }),
+            'success'
+          );
         } else {
           showNotification(
             t('auth_files.batch_status_partial', { success: successCount, failed: failCount }),
@@ -554,7 +608,7 @@ export function useAuthFilesData(): UseAuthFilesDataResult {
         });
       }
     },
-    [deselectAll, files, showNotification, statusUpdating, t]
+    [deselectAll, files, invalidateInFlightLoads, showNotification, statusUpdating, t]
   );
 
   const batchDownload = useCallback(
@@ -567,11 +621,7 @@ export function useAuthFilesData(): UseAuthFilesDataResult {
 
       for (const name of uniqueNames) {
         try {
-          const response = await apiClient.getRaw(
-            `/auth-files/download?name=${encodeURIComponent(name)}`,
-            { responseType: 'blob' }
-          );
-          const blob = new Blob([response.data]);
+          const blob = await authFilesApi.download(name);
           downloadBlob({ filename: name, blob });
           successCount++;
         } catch {
@@ -590,8 +640,9 @@ export function useAuthFilesData(): UseAuthFilesDataResult {
           'warning'
         );
       }
+      deselectAll();
     },
-    [showNotification, t]
+    [deselectAll, showNotification, t]
   );
 
   const batchDelete = useCallback(
@@ -639,6 +690,7 @@ export function useAuthFilesData(): UseAuthFilesDataResult {
     selectedFiles,
     selectionCount,
     loading,
+    refreshing,
     error,
     uploading,
     deleting,

--- a/src/features/authFiles/hooks/useAuthFilesModels.ts
+++ b/src/features/authFiles/hooks/useAuthFilesModels.ts
@@ -16,6 +16,7 @@ export type UseAuthFilesModelsResult = {
   modelsError: ModelsError;
   showModels: (item: AuthFileItem) => Promise<void>;
   closeModelsModal: () => void;
+  invalidateModels: (names?: string[]) => void;
 };
 
 export function useAuthFilesModels(): UseAuthFilesModelsResult {
@@ -29,32 +30,63 @@ export function useAuthFilesModels(): UseAuthFilesModelsResult {
   const [modelsFileType, setModelsFileType] = useState('');
   const [modelsError, setModelsError] = useState<ModelsError>(null);
   const modelsCacheRef = useRef<Map<string, AuthFileModelItem[]>>(new Map());
+  const modelsCacheVersionRef = useRef(0);
+  const modelsFileVersionRef = useRef<Map<string, number>>(new Map());
+  const activeModelsRequestIdRef = useRef(0);
 
   const closeModelsModal = useCallback(() => {
+    activeModelsRequestIdRef.current += 1;
     setModelsModalOpen(false);
+    setModelsLoading(false);
+  }, []);
+
+  const invalidateModels = useCallback((names?: string[]) => {
+    if (!names) {
+      modelsCacheRef.current.clear();
+      modelsFileVersionRef.current.clear();
+      modelsCacheVersionRef.current += 1;
+      return;
+    }
+    new Set(names.map((name) => name.trim()).filter(Boolean)).forEach((name) => {
+      modelsCacheRef.current.delete(name);
+      modelsFileVersionRef.current.set(name, (modelsFileVersionRef.current.get(name) ?? 0) + 1);
+    });
   }, []);
 
   const showModels = useCallback(
     async (item: AuthFileItem) => {
+      const cacheKey = item.name.trim();
+      const requestId = ++activeModelsRequestIdRef.current;
+
       setModelsFileName(item.name);
       setModelsFileType(item.type || '');
       setModelsList([]);
       setModelsError(null);
       setModelsModalOpen(true);
 
-      const cached = modelsCacheRef.current.get(item.name);
+      const cached = modelsCacheRef.current.get(cacheKey);
       if (cached) {
         setModelsList(cached);
         setModelsLoading(false);
         return;
       }
 
+      const cacheVersion = modelsCacheVersionRef.current;
+      const fileVersion = modelsFileVersionRef.current.get(cacheKey) ?? 0;
+      const isCacheCurrent = () =>
+        cacheVersion === modelsCacheVersionRef.current &&
+        fileVersion === (modelsFileVersionRef.current.get(cacheKey) ?? 0);
+      const isRequestCurrent = () => requestId === activeModelsRequestIdRef.current;
+
       setModelsLoading(true);
       try {
         const models = await authFilesApi.getModelsForAuthFile(item.name);
-        modelsCacheRef.current.set(item.name, models);
-        setModelsList(models);
+        if (isCacheCurrent()) {
+          modelsCacheRef.current.set(cacheKey, models);
+          if (isRequestCurrent()) setModelsList(models);
+        }
       } catch (err) {
+        if (!isRequestCurrent() || !isCacheCurrent()) return;
         const errorMessage = err instanceof Error ? err.message : '';
         if (
           errorMessage.includes('404') ||
@@ -66,7 +98,7 @@ export function useAuthFilesModels(): UseAuthFilesModelsResult {
           showNotification(`${t('notification.load_failed')}: ${errorMessage}`, 'error');
         }
       } finally {
-        setModelsLoading(false);
+        if (isRequestCurrent()) setModelsLoading(false);
       }
     },
     [showNotification, t]
@@ -80,7 +112,7 @@ export function useAuthFilesModels(): UseAuthFilesModelsResult {
     modelsFileType,
     modelsError,
     showModels,
-    closeModelsModal
+    closeModelsModal,
+    invalidateModels,
   };
 }
-

--- a/src/features/authFiles/hooks/useAuthFilesPrefixProxyEditor.ts
+++ b/src/features/authFiles/hooks/useAuthFilesPrefixProxyEditor.ts
@@ -62,6 +62,7 @@ export type PrefixProxyEditorState = {
 export type UseAuthFilesPrefixProxyEditorOptions = {
   disableControls: boolean;
   loadFiles: () => Promise<void>;
+  onFileMutated?: (name: string) => void;
 };
 
 export type UseAuthFilesPrefixProxyEditorResult = {
@@ -350,7 +351,7 @@ const buildPrefixProxyUpdatedText = (
 export function useAuthFilesPrefixProxyEditor(
   options: UseAuthFilesPrefixProxyEditorOptions
 ): UseAuthFilesPrefixProxyEditorResult {
-  const { disableControls, loadFiles } = options;
+  const { disableControls, loadFiles, onFileMutated } = options;
   const { t } = useTranslation();
   const showNotification = useNotificationStore((state) => state.showNotification);
 
@@ -548,6 +549,7 @@ export function useAuthFilesPrefixProxyEditor(
 
     try {
       await authFilesApi.patchFields(name, payload);
+      onFileMutated?.(name);
       showNotification(t('auth_files.prefix_proxy_saved_success', { name }), 'success');
       await loadFiles();
       setPrefixProxyEditor(null);

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -731,7 +731,8 @@
     "weekly_limit": "Weekly limit",
     "limit_window": "{{duration}} limit",
     "limit_index": "Limit #{{index}}",
-    "reset_hint": "resets in {{hint}}"
+    "reset_hint": "resets in {{hint}}",
+    "reset_at": "Resets {{time}}"
   },
   "xai_quota": {
     "title": "Grok Quota",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -726,7 +726,8 @@
     "weekly_limit": "Недельный лимит",
     "limit_window": "Лимит {{duration}}",
     "limit_index": "Лимит #{{index}}",
-    "reset_hint": "сброс через {{hint}}"
+    "reset_hint": "сброс через {{hint}}",
+    "reset_at": "Сброс {{time}}"
   },
   "xai_quota": {
     "title": "Квота Grok",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -731,7 +731,8 @@
     "weekly_limit": "周限额",
     "limit_window": "{{duration}} 限额",
     "limit_index": "限额 #{{index}}",
-    "reset_hint": "{{hint}} 后重置"
+    "reset_hint": "{{hint}} 后重置",
+    "reset_at": "{{time}} 重置"
   },
   "xai_quota": {
     "title": "Grok 额度",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -731,7 +731,8 @@
     "weekly_limit": "週限額",
     "limit_window": "{{duration}} 限額",
     "limit_index": "限額 #{{index}}",
-    "reset_hint": "{{hint}} 後重置"
+    "reset_hint": "{{hint}} 後重置",
+    "reset_at": "{{time}} 重置"
   },
   "xai_quota": {
     "title": "Grok 配額",

--- a/src/pages/AuthFilesPage.tsx
+++ b/src/pages/AuthFilesPage.tsx
@@ -34,7 +34,7 @@ import {
   getThemeSurfaceIconBackground,
   getTypeColor,
   getTypeLabel,
-  hasAuthFileStatusMessage,
+  isProblemAuthFile,
   isRuntimeOnlyAuthFile,
   isThemeSurfaceIconProvider,
   normalizeProviderKey,
@@ -47,6 +47,7 @@ import { AuthFileModelsModal } from '@/features/authFiles/components/AuthFileMod
 import { AuthFilesPrefixProxyEditorModal } from '@/features/authFiles/components/AuthFilesPrefixProxyEditorModal';
 import { OAuthExcludedCard } from '@/features/authFiles/components/OAuthExcludedCard';
 import { OAuthModelAliasCard } from '@/features/authFiles/components/OAuthModelAliasCard';
+import { invalidateAuthFileDerivedCaches } from '@/features/authFiles/cacheInvalidation';
 import {
   CodexRemoteCloudConnectEnvironmentsModal,
   areCodexRemoteCloudConnectEnvironmentSummariesEqual,
@@ -76,8 +77,7 @@ const BATCH_BAR_HIDDEN_TRANSFORM = 'translateX(-50%) translateY(56px)';
 const DEFAULT_REGULAR_PAGE_SIZE = 9;
 const DEFAULT_COMPACT_PAGE_SIZE = 12;
 
-const escapeWildcardSearchSegment = (value: string) =>
-  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const escapeWildcardSearchSegment = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 const buildWildcardSearch = (value: string): RegExp | null => {
   if (!value.includes('*')) return null;
@@ -118,10 +118,28 @@ export function AuthFilesPage() {
   const selectionCountRef = useRef(0);
 
   const {
+    modelsModalOpen,
+    modelsLoading,
+    modelsList,
+    modelsFileName,
+    modelsFileType,
+    modelsError,
+    showModels,
+    closeModelsModal,
+    invalidateModels,
+  } = useAuthFilesModels();
+
+  const invalidateDerivedCaches = useCallback(
+    (names?: string[]) => invalidateAuthFileDerivedCaches(invalidateModels, names),
+    [invalidateModels]
+  );
+
+  const {
     files,
     selectedFiles,
     selectionCount,
     loading,
+    refreshing,
     error,
     uploading,
     deleting,
@@ -143,7 +161,7 @@ export function AuthFilesPage() {
     batchDownload,
     batchSetStatus,
     batchDelete,
-  } = useAuthFilesData();
+  } = useAuthFilesData({ onFilesMutated: invalidateDerivedCaches });
 
   const statusBarCache = useAuthFilesStatusBarCache(files);
 
@@ -165,17 +183,6 @@ export function AuthFilesPage() {
   } = useAuthFilesOauth({ viewMode, files });
 
   const {
-    modelsModalOpen,
-    modelsLoading,
-    modelsList,
-    modelsFileName,
-    modelsFileType,
-    modelsError,
-    showModels,
-    closeModelsModal,
-  } = useAuthFilesModels();
-
-  const {
     prefixProxyEditor,
     prefixProxyUpdatedText,
     prefixProxyDirty,
@@ -186,6 +193,7 @@ export function AuthFilesPage() {
   } = useAuthFilesPrefixProxyEditor({
     disableControls: connectionStatus !== 'connected',
     loadFiles,
+    onFileMutated: (name) => invalidateDerivedCaches([name]),
   });
 
   const {
@@ -237,10 +245,7 @@ export function AuthFilesPage() {
       if (typeof persisted.disabledOnly === 'boolean') {
         setDisabledOnly(persisted.disabledOnly);
       }
-      if (
-        typeof persistedCompactMode !== 'boolean' &&
-        typeof persisted.compactMode === 'boolean'
-      ) {
+      if (typeof persistedCompactMode !== 'boolean' && typeof persisted.compactMode === 'boolean') {
         setCompactMode(persisted.compactMode);
       }
       if (typeof persisted.search === 'string') {
@@ -256,11 +261,11 @@ export function AuthFilesPage() {
       const regularPageSize =
         typeof persisted.regularPageSize === 'number' && Number.isFinite(persisted.regularPageSize)
           ? clampCardPageSize(persisted.regularPageSize)
-          : legacyPageSize ?? DEFAULT_REGULAR_PAGE_SIZE;
+          : (legacyPageSize ?? DEFAULT_REGULAR_PAGE_SIZE);
       const compactPageSize =
         typeof persisted.compactPageSize === 'number' && Number.isFinite(persisted.compactPageSize)
           ? clampCardPageSize(persisted.compactPageSize)
-          : legacyPageSize ?? DEFAULT_COMPACT_PAGE_SIZE;
+          : (legacyPageSize ?? DEFAULT_COMPACT_PAGE_SIZE);
       setPageSizeByMode({
         regular: regularPageSize,
         compact: compactPageSize,
@@ -375,7 +380,7 @@ export function AuthFilesPage() {
 
   useInterval(
     () => {
-      void loadFiles().catch(() => {});
+      void loadFiles({ background: true }).catch(() => {});
     },
     isCurrentLayer ? 240_000 : null
   );
@@ -392,7 +397,7 @@ export function AuthFilesPage() {
   const filesMatchingStatusFilters = useMemo(
     () =>
       files.filter((file) => {
-        if (problemOnly && !hasAuthFileStatusMessage(file)) return false;
+        if (problemOnly && !isProblemAuthFile(file)) return false;
         if (disabledOnly && file.disabled !== true) return false;
         return true;
       }),
@@ -693,7 +698,13 @@ export function AuthFilesPage() {
         title={titleNode}
         extra={
           <div className={styles.headerActions}>
-            <Button variant="secondary" size="sm" onClick={handleHeaderRefresh} disabled={loading}>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={handleHeaderRefresh}
+              disabled={loading || refreshing}
+              loading={loading || refreshing}
+            >
               {t('common.refresh')}
             </Button>
             <Button

--- a/src/services/api/authFiles.ts
+++ b/src/services/api/authFiles.ts
@@ -6,6 +6,11 @@ import { apiClient } from './client';
 import type { AuthFilesResponse } from '@/types/authFile';
 import type { OAuthModelAliasEntry } from '@/types';
 import { normalizeOAuthProviderKey } from '@/utils/providerKeys';
+import {
+  normalizeRecentRequestAuthIndex,
+  normalizeRecentRequestBuckets,
+  normalizeUsageTotal,
+} from '@/utils/recentRequests';
 import { parseTimestampMs } from '@/utils/timestamp';
 
 type StatusError = { status?: number };
@@ -155,7 +160,11 @@ const readDateField = (entry: AuthFileEntry): number => {
   return 0;
 };
 
-const isRuntimeOnlyEntry = (entry: AuthFileEntry): boolean => entry['runtime_only'] === true;
+const isRuntimeOnlyEntry = (entry: AuthFileEntry): boolean => {
+  const raw = entry['runtime_only'] ?? entry.runtimeOnly;
+  if (typeof raw === 'boolean') return raw;
+  return typeof raw === 'string' && raw.trim().toLowerCase() === 'true';
+};
 
 const hasMeaningfulValue = (value: unknown): boolean => {
   if (value == null) return false;
@@ -208,7 +217,41 @@ const mergeAuthFileEntries = (entries: AuthFileEntry[]): AuthFileEntry => {
   return merged;
 };
 
-const dedupeAuthFilesResponse = (payload: AuthFilesResponse): AuthFilesResponse => {
+const INTEGER_STRING_PATTERN = /^[+-]?\d+$/;
+
+const readPriorityField = (value: unknown): number | undefined => {
+  if (typeof value === 'number') return Number.isInteger(value) ? value : undefined;
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  if (!trimmed || !INTEGER_STRING_PATTERN.test(trimmed)) return undefined;
+  const parsed = Number.parseInt(trimmed, 10);
+  return Number.isSafeInteger(parsed) ? parsed : undefined;
+};
+
+/** Preserve raw provider fields while exposing stable camelCase fields to the UI. */
+const normalizeAuthFileEntry = (entry: AuthFileEntry): AuthFileEntry => {
+  const declaredStatusMessage =
+    typeof entry.statusMessage === 'string' ? entry.statusMessage.trim() : '';
+  const statusMessage = readTextField(entry, 'status_message') || declaredStatusMessage;
+  const note = readTextField(entry, 'note');
+  const modified = readDateField(entry);
+  const priority = readPriorityField(entry['priority']);
+
+  return {
+    ...entry,
+    runtimeOnly: isRuntimeOnlyEntry(entry),
+    authIndex: normalizeRecentRequestAuthIndex(entry['auth_index'] ?? entry.authIndex),
+    recentRequests: normalizeRecentRequestBuckets(entry.recent_requests ?? entry.recentRequests),
+    successCount: normalizeUsageTotal(entry.success),
+    failureCount: normalizeUsageTotal(entry.failed),
+    ...(statusMessage ? { statusMessage } : {}),
+    ...(modified > 0 ? { modified } : {}),
+    ...(priority !== undefined ? { priority } : {}),
+    ...(note ? { note } : {}),
+  };
+};
+
+export const normalizeAuthFilesResponse = (payload: AuthFilesResponse): AuthFilesResponse => {
   const files = Array.isArray(payload?.files) ? payload.files : [];
   const grouped = new Map<string, AuthFileEntry[]>();
 
@@ -223,7 +266,9 @@ const dedupeAuthFilesResponse = (payload: AuthFilesResponse): AuthFilesResponse 
     grouped.set(key, [entry]);
   });
 
-  const normalizedFiles = Array.from(grouped.values()).map(mergeAuthFileEntries);
+  const normalizedFiles = Array.from(grouped.values()).map((entries) =>
+    normalizeAuthFileEntry(mergeAuthFileEntries(entries))
+  );
   normalizedFiles.sort((left, right) =>
     readTextField(left, 'name').localeCompare(readTextField(right, 'name'), undefined, {
       sensitivity: 'accent',
@@ -367,7 +412,8 @@ export const serializeOauthModelAliases = (
 const OAUTH_MODEL_ALIAS_ENDPOINT = '/oauth-model-alias';
 
 export const authFilesApi = {
-  list: async () => dedupeAuthFilesResponse(await apiClient.get<AuthFilesResponse>('/auth-files')),
+  list: async () =>
+    normalizeAuthFilesResponse(await apiClient.get<AuthFilesResponse>('/auth-files')),
 
   setStatus: (name: string, disabled: boolean) =>
     apiClient.patch<AuthFileStatusResponse>('/auth-files/status', { name, disabled }),
@@ -407,14 +453,18 @@ export const authFilesApi = {
 
   deleteAll: () => apiClient.delete('/auth-files', { params: { all: true } }),
 
-  downloadText: async (name: string): Promise<string> => {
+  download: async (name: string): Promise<Blob> => {
     const response = await apiClient.getRaw(
       `/auth-files/download?name=${encodeURIComponent(name)}`,
       {
         responseType: 'blob',
       }
     );
-    const blob = response.data as Blob;
+    return response.data as Blob;
+  },
+
+  downloadText: async (name: string): Promise<string> => {
+    const blob = await authFilesApi.download(name);
     return blob.text();
   },
 

--- a/src/types/authFile.ts
+++ b/src/types/authFile.ts
@@ -33,8 +33,13 @@ export interface AuthFileItem {
   statusMessage?: string;
   lastRefresh?: string | number;
   modified?: number;
+  priority?: number;
+  note?: string;
   success?: unknown;
   failed?: unknown;
+  /** API 边界从 success / failed 原始字段归一化得到的累计计数。 */
+  successCount?: number;
+  failureCount?: number;
   recent_requests?: RecentRequestBucket[];
   recentRequests?: RecentRequestBucket[];
   [key: string]: unknown;

--- a/src/types/quota.ts
+++ b/src/types/quota.ts
@@ -451,6 +451,7 @@ export interface KimiUsageDetail {
 export interface KimiLimitWindow {
   duration?: number;
   timeUnit?: string;
+  time_unit?: string;
 }
 
 export interface KimiLimitItem {
@@ -464,6 +465,7 @@ export interface KimiLimitItem {
   remaining?: number;
   duration?: number;
   timeUnit?: string;
+  time_unit?: string;
   resetAt?: string;
   reset_at?: string;
   resetIn?: number;
@@ -484,6 +486,7 @@ export interface KimiQuotaRow {
   used: number;
   limit: number;
   resetHint?: string;
+  resetAtMs?: number | null;
 }
 
 export interface KimiQuotaState {

--- a/src/utils/quota/builders.ts
+++ b/src/utils/quota/builders.ts
@@ -128,7 +128,9 @@ export function buildGeminiCliQuotaBuckets(
       const remainingFraction = preferred
         ? preferred.remainingFraction
         : bucket.fallbackRemainingFraction;
-      const remainingAmount = preferred ? preferred.remainingAmount : bucket.fallbackRemainingAmount;
+      const remainingAmount = preferred
+        ? preferred.remainingAmount
+        : bucket.fallbackRemainingAmount;
       const resetTime = preferred ? preferred.resetTime : bucket.fallbackResetTime;
       return {
         id: bucket.id,
@@ -232,10 +234,7 @@ export function buildAntigravityQuotaGroups(
     };
   };
 
-  const appendGroup = (
-    id: string,
-    overrideResetTime?: string
-  ): AntigravityQuotaGroup | null => {
+  const appendGroup = (id: string, overrideResetTime?: string): AntigravityQuotaGroup | null => {
     const definition = definitions.get(id);
     if (!definition) return null;
     const group = buildGroup(definition, overrideResetTime);
@@ -281,46 +280,76 @@ function formatKimiResetDuration(totalMinutes: number): string {
   return '<1m';
 }
 
-function kimiResetHint(data: Record<string, unknown>): string | undefined {
-  const absoluteKeys = ['reset_at', 'resetAt', 'reset_time', 'resetTime'];
-  for (const key of absoluteKeys) {
+function kimiAbsoluteResetMs(data: Record<string, unknown>): number | null {
+  for (const key of ['reset_at', 'resetAt', 'reset_time', 'resetTime']) {
     const raw = data[key];
-    if (typeof raw === 'string' && raw.trim()) {
-      try {
-        const truncated = raw.replace(/(\.\d{6})\d+/, '$1');
-        const date = new Date(truncated);
-        if (Number.isNaN(date.getTime())) continue;
-        const now = Date.now();
-        const delta = date.getTime() - now;
-        if (delta <= 0) return undefined;
-        const totalMinutes = Math.floor(delta / 60000);
-        return formatKimiResetDuration(totalMinutes);
-      } catch {
-        continue;
-      }
+    if (typeof raw === 'number' && Number.isFinite(raw) && raw > 0) {
+      return raw < 1e12 ? raw * 1000 : raw;
     }
+    if (typeof raw !== 'string' || !raw.trim()) continue;
+    const trimmed = raw.trim();
+    const numeric = Number(trimmed);
+    if (Number.isFinite(numeric) && numeric > 0) {
+      return numeric < 1e12 ? numeric * 1000 : numeric;
+    }
+    const parsed = new Date(trimmed.replace(/(\.\d{6})\d+/, '$1')).getTime();
+    if (!Number.isNaN(parsed)) return parsed;
   }
 
-  const relativeKeys = ['reset_in', 'resetIn', 'ttl'];
-  for (const key of relativeKeys) {
-    const raw = toInt(data[key]);
-    if (raw !== null && raw > 0) {
-      const totalMinutes = Math.floor(raw / 60);
-      return formatKimiResetDuration(totalMinutes);
+  return null;
+}
+
+function kimiResetMs(data: Record<string, unknown>): number | null {
+  const absolute = kimiAbsoluteResetMs(data);
+  if (absolute !== null) return absolute;
+  for (const key of ['reset_in', 'resetIn', 'ttl']) {
+    const seconds = toInt(data[key]);
+    if (seconds !== null && seconds > 0) return Date.now() + seconds * 1000;
+  }
+  return null;
+}
+
+function kimiResetHint(data: Record<string, unknown>): string | undefined {
+  const absolute = kimiAbsoluteResetMs(data);
+  if (absolute !== null) {
+    const delta = absolute - Date.now();
+    if (delta <= 0) return undefined;
+    return formatKimiResetDuration(Math.floor(delta / 60000));
+  }
+  for (const key of ['reset_in', 'resetIn', 'ttl']) {
+    const seconds = toInt(data[key]);
+    if (seconds !== null && seconds > 0) {
+      return formatKimiResetDuration(Math.floor(seconds / 60));
     }
   }
-
   return undefined;
 }
 
+type KimiTimeUnit = 'second' | 'minute' | 'hour' | 'day' | 'week';
+
+function normalizeKimiTimeUnit(rawTimeUnit: unknown): KimiTimeUnit | null {
+  const unit =
+    typeof rawTimeUnit === 'string'
+      ? rawTimeUnit
+          .trim()
+          .toUpperCase()
+          .replace(/^TIME_UNIT_/, '')
+      : '';
+  if (unit === 'SECONDS' || unit === 'SECOND') return 'second';
+  if (!unit || unit === 'MINUTES' || unit === 'MINUTE') return 'minute';
+  if (unit === 'HOURS' || unit === 'HOUR') return 'hour';
+  if (unit === 'DAYS' || unit === 'DAY') return 'day';
+  if (unit === 'WEEKS' || unit === 'WEEK') return 'week';
+  return null;
+}
+
 function kimiDurationToken(duration: number, rawTimeUnit: unknown): string {
-  const unit = typeof rawTimeUnit === 'string' ? rawTimeUnit.trim().toUpperCase() : '';
-  if (unit === 'MINUTES') {
-    return duration % 60 === 0 ? `${duration / 60}h` : `${duration}m`;
-  }
-  if (unit === 'HOURS') return `${duration}h`;
-  if (unit === 'DAYS') return `${duration}d`;
-  return `${duration}s`;
+  const unit = normalizeKimiTimeUnit(rawTimeUnit);
+  if (unit === 'second') return `${duration}s`;
+  if (unit === 'hour') return `${duration}h`;
+  if (unit === 'day') return `${duration}d`;
+  if (unit === 'week') return `${duration}w`;
+  return duration % 60 === 0 ? `${duration / 60}h` : `${duration}m`;
 }
 
 function kimiLimitLabel(
@@ -340,8 +369,11 @@ function kimiLimitLabel(
     toInt((detail as Record<string, unknown>).duration);
   const timeUnit =
     (window as Record<string, unknown>).timeUnit ??
+    (window as Record<string, unknown>).time_unit ??
     (item as Record<string, unknown>).timeUnit ??
-    (detail as Record<string, unknown>).timeUnit;
+    (item as Record<string, unknown>).time_unit ??
+    (detail as Record<string, unknown>).timeUnit ??
+    (detail as Record<string, unknown>).time_unit;
 
   if (duration !== null && duration > 0) {
     return {
@@ -363,7 +395,9 @@ function kimiLimitLabel(
 function toKimiUsageRow(
   data: Record<string, unknown>,
   fallbackLabel: KimiRowLabel
-): (KimiRowLabel & { used: number; limit: number; resetHint?: string }) | null {
+):
+  | (KimiRowLabel & { used: number; limit: number; resetHint?: string; resetAtMs?: number | null })
+  | null {
   const limit = toInt(data.limit);
   let used = toInt(data.used);
   if (used === null) {
@@ -382,6 +416,7 @@ function toKimiUsageRow(
     used: used ?? 0,
     limit: limit ?? 0,
     resetHint: kimiResetHint(data),
+    resetAtMs: kimiResetMs(data),
   };
 }
 
@@ -391,8 +426,12 @@ export function buildKimiQuotaRows(payload: KimiUsagePayload): KimiQuotaRow[] {
   const limits = payload.limits;
   if (Array.isArray(limits)) {
     limits.forEach((item, idx) => {
-      const detail = (item.detail && typeof item.detail === 'object' ? item.detail : item) as KimiUsageDetail | KimiLimitItem;
-      const window = (item.window && typeof item.window === 'object' ? item.window : {}) as KimiLimitWindow;
+      const detail = (item.detail && typeof item.detail === 'object' ? item.detail : item) as
+        | KimiUsageDetail
+        | KimiLimitItem;
+      const window = (
+        item.window && typeof item.window === 'object' ? item.window : {}
+      ) as KimiLimitWindow;
       const fallbackLabel = kimiLimitLabel(item, detail, window, idx);
       const row = toKimiUsageRow(detail as Record<string, unknown>, fallbackLabel);
       if (row) {
@@ -550,12 +589,20 @@ export function mergeXaiBillingSummaries(
 ): XaiBillingSummary | null {
   if (!primary) return fallback;
   if (!fallback) return primary;
+  // Weekly and monthly endpoints describe different clocks. Keep the selected
+  // period type and its dates from the same response instead of mixing fields.
+  const periodSummary =
+    primary.periodType !== 'unknown'
+      ? primary
+      : fallback.periodType !== 'unknown'
+        ? fallback
+        : primary;
 
   return {
-    periodType: primary.periodType !== 'unknown' ? primary.periodType : fallback.periodType,
+    periodType: periodSummary.periodType,
     usagePercent: primary.usagePercent ?? fallback.usagePercent,
-    periodStart: primary.periodStart ?? fallback.periodStart,
-    periodEnd: primary.periodEnd ?? fallback.periodEnd,
+    periodStart: periodSummary.periodStart,
+    periodEnd: periodSummary.periodEnd,
     productUsage: primary.productUsage.length > 0 ? primary.productUsage : fallback.productUsage,
     monthlyLimitCents: primary.monthlyLimitCents ?? fallback.monthlyLimitCents,
     usedCents: primary.usedCents ?? fallback.usedCents,

--- a/src/utils/quota/upstreamQuotaPort.test.mjs
+++ b/src/utils/quota/upstreamQuotaPort.test.mjs
@@ -12,7 +12,7 @@ const vite = await createServer({
 });
 
 const [
-  { buildKimiQuotaRows },
+  { buildKimiQuotaRows, mergeXaiBillingSummaries },
   { buildClaudeQuotaWindows },
   {
     buildCodexAnalyticsRange,
@@ -21,11 +21,17 @@ const [
     selectCodexDailyUsageDays,
   },
   authFileConstants,
+  { invalidateAuthFileDerivedCaches },
+  { useQuotaStore },
+  { normalizeAuthFilesResponse },
 ] = await Promise.all([
   vite.ssrLoadModule('/src/utils/quota/builders.ts'),
   vite.ssrLoadModule('/src/components/quota/quotaConfigs.ts'),
   vite.ssrLoadModule('/src/lts/codexQuota/config.ts'),
   vite.ssrLoadModule('/src/features/authFiles/constants.ts'),
+  vite.ssrLoadModule('/src/features/authFiles/cacheInvalidation.ts'),
+  vite.ssrLoadModule('/src/stores/useQuotaStore.ts'),
+  vite.ssrLoadModule('/src/services/api/authFiles.ts'),
 ]);
 
 test.after(async () => {
@@ -65,6 +71,115 @@ test('formats Kimi reset durations longer than one day as days and hours', () =>
   assert.equal(resetHint(168 * 3600), '7d 0h');
   assert.equal(resetHint(5 * 3600 + 30 * 60), '5h 30m');
   assert.equal(resetHint(59), '<1m');
+});
+
+test('normalizes Kimi protobuf week units and retains the concrete reset instant', () => {
+  const resetAt = '2099-08-03T12:34:56.000Z';
+  const rows = buildKimiQuotaRows({
+    limits: [
+      {
+        detail: { used: 1, limit: 10, reset_at: resetAt },
+        window: { duration: 1, time_unit: 'TIME_UNIT_WEEK' },
+      },
+    ],
+  });
+
+  assert.equal(rows[0]?.labelParams?.duration, '1w');
+  assert.equal(rows[0]?.resetAtMs, Date.parse(resetAt));
+});
+
+test('keeps xAI period type and dates from one endpoint', () => {
+  const weekly = {
+    periodType: 'weekly',
+    usagePercent: 25,
+    periodStart: '2026-08-01T00:00:00Z',
+    periodEnd: undefined,
+    productUsage: [],
+    monthlyLimitCents: null,
+    usedCents: null,
+    includedUsedCents: null,
+    onDemandCapCents: null,
+    onDemandUsedCents: null,
+    onDemandUsedPercent: null,
+    usedPercent: null,
+  };
+  const monthly = {
+    ...weekly,
+    periodType: 'monthly',
+    periodStart: '2026-08-01T00:00:00Z',
+    periodEnd: '2026-09-01T00:00:00Z',
+    monthlyLimitCents: 2000,
+  };
+
+  const merged = mergeXaiBillingSummaries(weekly, monthly);
+  assert.equal(merged?.periodType, 'weekly');
+  assert.equal(merged?.periodStart, weekly.periodStart);
+  assert.equal(merged?.periodEnd, undefined);
+});
+
+test('treats disabled credentials separately from actionable problem states', () => {
+  const { isProblemAuthFile } = authFileConstants;
+  assert.equal(isProblemAuthFile({ name: 'disabled', disabled: true, status: 'error' }), false);
+  assert.equal(
+    isProblemAuthFile({ name: 'status-disabled', status: 'disabled', unavailable: true }),
+    false
+  );
+  assert.equal(isProblemAuthFile({ name: 'unavailable', unavailable: true }), true);
+  assert.equal(isProblemAuthFile({ name: 'error', status: 'error' }), true);
+  assert.equal(isProblemAuthFile({ name: 'healthy', statusMessage: 'healthy' }), false);
+  assert.equal(isProblemAuthFile({ name: 'warning', statusMessage: 'token expired' }), true);
+});
+
+test('invalidates model and quota caches together after auth-file mutation', () => {
+  let invalidatedNames = null;
+  useQuotaStore.getState().setKimiQuota({
+    'auth.json': { status: 'idle', rows: [] },
+  });
+  const before = useQuotaStore.getState().cacheGeneration;
+
+  invalidateAuthFileDerivedCaches(
+    (names) => {
+      invalidatedNames = names;
+    },
+    ['auth.json']
+  );
+
+  assert.deepEqual(invalidatedNames, ['auth.json']);
+  assert.equal(useQuotaStore.getState().cacheGeneration, before + 1);
+  assert.deepEqual(useQuotaStore.getState().kimiQuota, {});
+});
+
+test('normalizes auth-file boundary fields without dropping raw provider data', () => {
+  const normalized = normalizeAuthFilesResponse({
+    files: [
+      {
+        name: 'auth.json',
+        runtime_only: 'true',
+        auth_index: 42,
+        status_message: ' ready ',
+        recent_requests: [{ time: '10:00-10:10', success: '2', failed: 1 }],
+        success: '3',
+        failed: 2,
+        priority: '7',
+        note: ' test note ',
+        modtime: '2026-08-03T00:00:00Z',
+        provider_specific: { retained: true },
+      },
+    ],
+  });
+
+  const file = normalized.files[0];
+  assert.equal(file.runtimeOnly, true);
+  assert.equal(file.authIndex, '42');
+  assert.equal(file.statusMessage, 'ready');
+  assert.equal(file.successCount, 3);
+  assert.equal(file.failureCount, 2);
+  assert.equal(file.priority, 7);
+  assert.equal(file.note, 'test note');
+  assert.equal(file.modified, Date.parse('2026-08-03T00:00:00Z'));
+  assert.deepEqual(file.recentRequests, [{ time: '10:00-10:10', success: 2, failed: 1 }]);
+  assert.deepEqual(file.provider_specific, { retained: true });
+  assert.equal(file.status_message, ' ready ');
 });
 
 test('slices one Codex daily payload into exact rolling ranges before aggregation', () => {


### PR DESCRIPTION
## 结果

按 CPA-Panel-LTS 的 protected selective-port 规则审计 `v1.20.0..v1.21.4`，只移植与现有 LTS 架构兼容的 auth-file、quota 和 Sheet 正确性修复。未接入上游 Vault/AuthFiles 大重构、QuotaPage/Timeline 新架构、WRR、excluded-model 新契约或商业推广面。

本 PR 保留两个独立审计单元：代码适配与七天 upstream intake 记录。合入 `main` 使用 merge commit；尚未创建 tag、Release、`management.html` 资产或部署运行时。

## Upstream 审计

- 范围：`1708314bc7a27e0ad9ef86b083e28e4e00aceeb1` (`v1.20.0`) → `30478c539c1f06649ac78deebeff6cfc227bbe22` (`v1.21.4`)
- first-parent non-merge commits：56
- 原始 diff：180 files，`+18,426/-8,505`
- 分类：1 `direct-port`、11 `adapt-port`、6 `already-equivalent`、1 `reject`、37 `defer`
- 完整逐 commit 证据和依赖链写入 `docs/lts/sync-runbook.md`

接纳的 12 个修复：

- `dbe7094`、`20c0cb8`、`3c8eba3`、`966a291`、`840df32`、`b76037a`、`c9636a3`：auth-file API 边界归一化、后台刷新、stale request 隔离、并发上传门禁、problem 状态语义，以及 model/quota cache 失效。
- `66d24c0`：reset 期间阻止单卡/全量 quota refresh。
- `ea0652c`：xAI period type/start/end 保持来自同一 endpoint。
- `b2bd48e`、`30478c5`：Kimi `TIME_UNIT_*`/week 归一化及 concrete reset timestamp 展示。
- `648a3d4`：Sheet 打开时重置 body scroll，并以 `preventScroll` 聚焦。

明确拒绝 `fb6d947`：它删除的 auth-file view-mode/too-many-files locale keys 仍被当前 LTS `QuotaSection` 使用。其余大系列按依赖和 LTS seam 记录为 `defer` 或 `already-equivalent`。

## LTS 兼容边界

以下保持不变：

- 完整 `/usage` 页面、usage import/export、pricing、request events 与 provider status 链路
- CPA-Core-LTS Management API 路径和 response contract
- `src/lts/codexQuota/`、`src/lts/codexRemoteCloudConnect/` 及 LTS locale overlays
- `package.json`、`package-lock.json`
- Release workflow 与 `management.html` 资产名

## 验证

以下均在本 PR exact head 对应内容上通过：

- `npm run validate:lts`
  - Node regression suites
  - Panel LTS/feature contract
  - TypeScript type-check
  - ESLint
  - production build
- `npm run smoke:lts`
- `npm run smoke:lts:core -- --no-write-smoke`
- 文档修正后的 `npm run check:lts`
- `git diff --check origin/main...HEAD`

浏览器 smoke 使用 mock Core 与本地临时 Core；没有生产部署或外部业务写入。

## Review focus

- `src/features/authFiles/hooks/useAuthFilesData.ts` 的 request generation 与 mutation 失效顺序
- `src/features/authFiles/hooks/useAuthFilesModels.ts` 的全局/单文件 cache version
- `src/utils/quota/builders.ts` 的 Kimi reset 与 xAI period 原子性
- `docs/lts/sync-runbook.md` 的 56-commit 分类和明确 defer/reject 边界