### PR TITLE
fix(navigation): 恢复日志入口并开放提供商工作台导航

### DIFF
--- a/scripts/smoke-lts-panel.py
+++ b/scripts/smoke-lts-panel.py
@@ -77,6 +77,7 @@ class MockCoreState:
         self.plugin_endpoint_available = True
         self.plugins_config_enabled = True
         self.include_branded_providers = True
+        self.logging_to_file = True
         self.plugin_enabled = True
         self.oauth_excluded_status = 200
         self.oauth_model_alias_status = 200
@@ -117,6 +118,7 @@ def build_recent_buckets() -> list[dict[str, Any]]:
 def build_config_payload(
     include_branded_providers: bool = True,
     plugins_enabled: bool = True,
+    logging_to_file: bool = True,
 ) -> dict[str, Any]:
     claude_api_keys = [
         {
@@ -215,7 +217,7 @@ def build_config_payload(
         "debug": False,
         "usage-statistics-enabled": True,
         "request-log": True,
-        "logging-to-file": True,
+        "logging-to-file": logging_to_file,
         "transient-error-cooldown-seconds": 30,
         "routing": {"strategy": "round-robin"},
         "api-keys": ["mgmt-key-1"],
@@ -1018,6 +1020,7 @@ class MockCoreHandler(BaseHTTPRequestHandler):
         config_payload = build_config_payload(
             include_branded_providers=self.state.include_branded_providers,
             plugins_enabled=self.state.plugins_config_enabled,
+            logging_to_file=self.state.logging_to_file,
         )
 
         if path == "/v0/management/config" and self.state.delay_next_config_response:
@@ -5041,7 +5044,7 @@ def run_plugin_runtime_mismatch_smoke(
         state.plugins_config_enabled = True
 
 
-def run_sidebar_navigation_smoke(page: Any) -> None:
+def run_sidebar_navigation_smoke(page: Any, state: MockCoreState) -> None:
     navigation = page.get_by_role("navigation", name="Primary navigation")
     navigation.wait_for()
 
@@ -5049,6 +5052,45 @@ def run_sidebar_navigation_smoke(page: Any) -> None:
         navigation.locator(
             ".nav-group-label", has_text=re.compile(f"^{re.escape(group_label)}$")
         ).wait_for()
+
+    state.logging_to_file = False
+    try:
+        with page.expect_response(
+            lambda response: response.request.method == "GET"
+            and response.url.endswith("/v0/management/config")
+        ):
+            page.reload(wait_until="domcontentloaded")
+        page.get_by_text("System Overview", exact=False).first.wait_for()
+        navigation = page.get_by_role("navigation", name="Primary navigation")
+        if navigation.get_by_role("link", name="Logs Viewer", exact=True).count() != 1:
+            raise AssertionError(
+                "Logs navigation disappeared when logging-to-file was disabled"
+            )
+    finally:
+        state.logging_to_file = True
+        with page.expect_response(
+            lambda response: response.request.method == "GET"
+            and response.url.endswith("/v0/management/config")
+        ):
+            page.reload(wait_until="domcontentloaded")
+        page.get_by_text("System Overview", exact=False).first.wait_for()
+        navigation = page.get_by_role("navigation", name="Primary navigation")
+
+    providers_drawer = navigation.get_by_role("button", name="AI Providers", exact=True)
+    if providers_drawer.count() != 1:
+        raise AssertionError("AI Providers navigation did not expose the Workbench drawer")
+    if providers_drawer.get_attribute("aria-expanded") != "false":
+        raise AssertionError("AI Providers drawer must start collapsed away from Provider routes")
+    providers_drawer.click()
+    workbench_link = navigation.get_by_role("link", name="Provider Workbench", exact=True)
+    workbench_link.wait_for()
+    workbench_link.click()
+    page.wait_for_function("() => window.location.hash.endsWith('/ai-providers/workbench')")
+    if providers_drawer.get_attribute("aria-expanded") != "true":
+        raise AssertionError("Active Provider Workbench did not keep its drawer open")
+    providers_drawer.click()
+    if providers_drawer.get_attribute("aria-expanded") != "false":
+        raise AssertionError("Active AI Providers drawer could not be manually collapsed")
 
     usage_drawer = navigation.get_by_role("button", name="Usage Statistics", exact=True)
     if usage_drawer.get_attribute("aria-expanded") != "false":
@@ -5178,7 +5220,7 @@ def run_browser_smoke(app_url: str, api_url: str, state: MockCoreState, headed: 
                 raise AssertionError("Remember password checkbox did not become checked")
             page.get_by_role("button", name=re.compile("Login|Connect", re.I)).click()
             page.wait_for_url(re.compile(r".*/#/$"), timeout=20_000)
-            run_sidebar_navigation_smoke(page)
+            run_sidebar_navigation_smoke(page, state)
 
             route_checks = [
                 ("/", "System Overview", None),

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -514,11 +514,21 @@ export function MainLayout() {
       label: t('nav_groups.gateway'),
       items: [
         {
-          kind: 'link',
+          kind: 'drawer',
+          id: 'ai-providers',
           path: '/ai-providers',
           label: t('nav.ai_providers'),
           meta: t('nav_meta.ai_providers'),
           icon: sidebarIcons.aiProviders,
+          children: [
+            {
+              kind: 'link',
+              path: '/ai-providers/workbench',
+              label: t('nav.provider_workbench'),
+              icon: <span className="nav-sub-dot" aria-hidden="true" />,
+              end: true,
+            },
+          ],
         },
         {
           kind: 'link',
@@ -564,17 +574,13 @@ export function MainLayout() {
             },
           ],
         },
-        ...(config?.loggingToFile
-          ? [
-              {
-                kind: 'link' as const,
-                path: '/logs',
-                label: t('nav.logs'),
-                meta: t('nav_meta.logs'),
-                icon: sidebarIcons.logs,
-              },
-            ]
-          : []),
+        {
+          kind: 'link',
+          path: '/logs',
+          label: t('nav.logs'),
+          meta: t('nav_meta.logs'),
+          icon: sidebarIcons.logs,
+        },
       ],
     },
     {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -113,6 +113,7 @@
     "basic_settings": "Basic Settings",
     "api_keys": "API Keys",
     "ai_providers": "AI Providers",
+    "provider_workbench": "Provider Workbench",
     "auth_files": "Auth Files",
     "oauth": "OAuth Login",
     "quota_management": "Quota Management",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -113,6 +113,7 @@
     "basic_settings": "Основные настройки",
     "api_keys": "API ключи",
     "ai_providers": "Поставщики AI",
+    "provider_workbench": "Рабочая область поставщиков",
     "auth_files": "Файлы аутентификации",
     "oauth": "OAuth вход",
     "quota_management": "Управление квотами",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -113,6 +113,7 @@
     "basic_settings": "基础设置",
     "api_keys": "API 密钥",
     "ai_providers": "AI 提供商",
+    "provider_workbench": "提供商工作台",
     "auth_files": "认证文件",
     "oauth": "OAuth 登录",
     "quota_management": "配额管理",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -113,6 +113,7 @@
     "basic_settings": "基本設定",
     "api_keys": "API 金鑰",
     "ai_providers": "AI 供應商",
+    "provider_workbench": "供應商工作台",
     "auth_files": "驗證檔案",
     "oauth": "OAuth 登入",
     "quota_management": "配額管理",


### PR DESCRIPTION
## 结果

修复两个已存在页面缺少稳定导航入口的问题：文件日志关闭时左侧不再隐藏“日志查看”，并为已注册的 Provider Workbench 增加可发现的侧栏子入口。

## 变更

- “日志查看”始终显示；`logging-to-file` 关闭时仍由日志页展示运行时提示，而不是移除入口。
- 将“AI 提供商”调整为 drawer：主项继续进入 `/ai-providers`，子项“提供商工作台”进入 `/ai-providers/workbench`。
- 补齐 `en`、`zh-CN`、`zh-TW`、`ru` 四种活动语言的 Workbench 导航文案。
- 扩展 mock browser smoke，覆盖文件日志关闭时的日志入口，以及 Provider drawer 的展开、跳转、活动状态和手动收起。

## 兼容性边界

- 不替换稳定版 Provider 页面，不改变完整 usage-backed provider status。
- 不改变 Management API、日志 API、Provider 数据或写入契约。
- 不改变插件 capability gate、`/usage` 保护链或 `management.html` 发布契约。
- 本 PR 不包含发布或部署。

## 验证

- 修复前定向浏览器断言：`Logs navigation disappeared when logging-to-file was disabled`
- 修复前定向浏览器断言：`AI Providers navigation did not expose the Workbench drawer`
- `npm run type-check`
- `npm run lint`
- `npm run check:lts`
- `npm run smoke:lts`
- `git diff --check`
