### PR TITLE
feat(quota): 适配 v1.22.2 视觉壳并保留 LTS 行为

### DIFF
--- a/src/components/quota/QuotaCard.tsx
+++ b/src/components/quota/QuotaCard.tsx
@@ -7,8 +7,13 @@ import type { ReactElement, ReactNode } from 'react';
 import type { TFunction } from 'i18next';
 import { Button } from '@/components/ui/Button';
 import { IconRefreshCw } from '@/components/ui/icons';
-import type { AuthFileItem, ResolvedTheme, ThemeColors } from '@/types';
-import { TYPE_COLORS } from '@/utils/quota';
+import {
+  getAuthFileIcon,
+  getThemeSurfaceIconBackground,
+  getTypeLabel,
+  isThemeSurfaceIconProvider,
+} from '@/features/authFiles/constants';
+import type { AuthFileItem, ResolvedTheme } from '@/types';
 import styles from '@/pages/QuotaPage.module.scss';
 
 type QuotaStatus = 'idle' | 'loading' | 'success' | 'error';
@@ -94,9 +99,8 @@ export function QuotaCard<TState extends QuotaStatusState>({
   const { t } = useTranslation();
 
   const displayType = item.type || item.provider || defaultType;
-  const typeColorSet = TYPE_COLORS[displayType] || TYPE_COLORS.unknown;
-  const typeColor: ThemeColors =
-    resolvedTheme === 'dark' && typeColorSet.dark ? typeColorSet.dark : typeColorSet.light;
+  const typeLabel = getTypeLabel(t, displayType);
+  const iconSrc = getAuthFileIcon(displayType, resolvedTheme);
 
   const quotaStatus = quota?.status ?? 'idle';
   const quotaLoading = quotaStatus === 'loading';
@@ -109,48 +113,61 @@ export function QuotaCard<TState extends QuotaStatusState>({
     ? `${i18nPrefix}.idle`
     : (cardIdleMessageKey ?? `${i18nPrefix}.idle`);
 
-  const getTypeLabel = (type: string): string => {
-    const key = `auth_files.filter_${type}`;
-    const translated = t(key);
-    if (translated !== key) return translated;
-    if (type.toLowerCase() === 'iflow') return 'iFlow';
-    return type.charAt(0).toUpperCase() + type.slice(1);
-  };
-
   return (
-    <div className={`${styles.fileCard} ${cardClassName}`}>
+    <div className={`${styles.fileCard} ${cardClassName}`} role="article">
       <div className={styles.cardHeader}>
         <span
-          className={styles.typeBadge}
-          style={{
-            backgroundColor: typeColor.bg,
-            color: typeColor.text,
-            ...(typeColor.border ? { border: typeColor.border } : {}),
-          }}
+          className={styles.providerIconWrap}
+          title={typeLabel}
+          style={
+            isThemeSurfaceIconProvider(displayType)
+              ? { background: getThemeSurfaceIconBackground(resolvedTheme) }
+              : undefined
+          }
         >
-          {getTypeLabel(displayType)}
+          {iconSrc ? (
+            <img src={iconSrc} alt="" className={styles.providerIcon} />
+          ) : (
+            <span className={styles.providerIconFallback}>
+              {typeLabel.slice(0, 1).toUpperCase()}
+            </span>
+          )}
         </span>
-        <span className={styles.fileName}>{item.name}</span>
+        <span className={styles.cardIdentity}>
+          <span className={styles.fileName} title={item.name}>
+            {item.name}
+          </span>
+          <span className={styles.providerName}>{typeLabel}</span>
+        </span>
       </div>
 
       <div className={styles.quotaSection}>
         {quotaLoading ? (
-          <div className={styles.quotaMessage}>{t(`${i18nPrefix}.loading`)}</div>
+          <div className={styles.quotaSkeleton} aria-busy="true">
+            <span className={styles.srOnly}>{t(`${i18nPrefix}.loading`)}</span>
+            {[0, 1].map((row) => (
+              <span key={row} className={styles.quotaSkeletonRow} aria-hidden="true">
+                <span className={styles.quotaSkeletonLabel} />
+                <span className={styles.quotaSkeletonTrack} />
+              </span>
+            ))}
+          </div>
         ) : quotaStatus === 'idle' ? (
           onRefresh ? (
             <button
               type="button"
-              className={`${styles.quotaMessage} ${styles.quotaMessageAction}`}
+              className={styles.quotaIdleAction}
               onClick={onRefresh}
               disabled={!canRefresh}
             >
-              {t(idleMessageKey)}
+              <IconRefreshCw size={15} aria-hidden="true" />
+              <span>{t(idleMessageKey)}</span>
             </button>
           ) : (
             <div className={styles.quotaMessage}>{t(idleMessageKey)}</div>
           )
         ) : quotaStatus === 'error' ? (
-          <div className={styles.quotaError}>
+          <div className={styles.quotaError} role="alert">
             {t(`${i18nPrefix}.load_failed`, {
               message: quotaErrorMessage,
             })}

--- a/src/features/authFiles/components/ProviderTabs.module.scss
+++ b/src/features/authFiles/components/ProviderTabs.module.scss
@@ -1,0 +1,135 @@
+@use '../../../styles/mixins' as *;
+
+.tabs {
+  display: flex;
+  align-items: stretch;
+  gap: 2px;
+  overflow-x: auto;
+  border-bottom: 1px solid var(--border-color);
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+.tab {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  flex-shrink: 0;
+  border: 0;
+  background: none;
+  cursor: pointer;
+  padding: 8px 12px 11px;
+  border-radius: 8px 8px 0 0;
+  font-size: 13px;
+  font-weight: 550;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  transition:
+    color var(--dur-hover, 200ms) var(--ease-out-strong, ease-out),
+    background-color var(--dur-hover, 200ms) var(--ease-out-strong, ease-out);
+
+  &::after {
+    content: '';
+    position: absolute;
+    left: 10px;
+    right: 10px;
+    bottom: -1px;
+    height: 2px;
+    border-radius: $radius-full;
+    background: transparent;
+    transition: background-color var(--dur-hover, 200ms) var(--ease-out-strong, ease-out);
+  }
+
+  &:active {
+    transform: translateY(0.5px);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--primary-color);
+    outline-offset: -2px;
+  }
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .tab:hover {
+    color: var(--text-primary);
+    background: color-mix(in srgb, var(--bg-tertiary) 55%, transparent);
+  }
+}
+
+.tabActive {
+  color: var(--text-primary);
+  font-weight: 650;
+
+  &::after {
+    background: var(--text-primary);
+  }
+}
+
+.tabGlyph {
+  flex-shrink: 0;
+  color: var(--text-tertiary);
+
+  .tabActive & {
+    color: var(--text-primary);
+  }
+}
+
+.tabIconWrap {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 5px;
+}
+
+.tabIcon {
+  width: 15px;
+  height: 15px;
+  object-fit: contain;
+  display: block;
+}
+
+.tabIconFallback {
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--text-secondary);
+}
+
+.tabLabel {
+  line-height: 1.4;
+}
+
+.tabCount {
+  font-family: $font-mono;
+  font-size: 10.5px;
+  font-weight: 650;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.6;
+  color: var(--text-tertiary);
+  padding: 0 6px;
+  border-radius: $radius-full;
+  background: color-mix(in srgb, var(--text-primary) 6%, transparent);
+
+  .tabActive & {
+    color: var(--text-primary);
+    background: color-mix(in srgb, var(--text-primary) 10%, transparent);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tab,
+  .tab::after {
+    transition: none;
+  }
+
+  .tab:active {
+    transform: none;
+  }
+}

--- a/src/features/authFiles/components/ProviderTabs.tsx
+++ b/src/features/authFiles/components/ProviderTabs.tsx
@@ -1,0 +1,66 @@
+import { useTranslation } from 'react-i18next';
+import { IconFilterAll } from '@/components/ui/icons';
+import {
+  getAuthFileIcon,
+  getThemeSurfaceIconBackground,
+  getTypeLabel,
+  isThemeSurfaceIconProvider,
+  type ResolvedTheme,
+} from '@/features/authFiles/constants';
+import styles from './ProviderTabs.module.scss';
+
+export type ProviderTabsProps = {
+  types: string[];
+  counts: Record<string, number>;
+  active: string;
+  resolvedTheme: ResolvedTheme;
+  onChange: (type: string) => void;
+};
+
+/** Provider filter tabs shared by quota-oriented credential surfaces. */
+export function ProviderTabs({ types, counts, active, resolvedTheme, onChange }: ProviderTabsProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div className={styles.tabs} role="group" aria-label={t('auth_files.filter_all')}>
+      {types.map((type) => {
+        const isActive = active === type;
+        const label = type === 'all' ? t('auth_files.filter_all') : getTypeLabel(t, type);
+        const iconSrc = type === 'all' ? null : getAuthFileIcon(type, resolvedTheme);
+
+        return (
+          <button
+            key={type}
+            type="button"
+            className={`${styles.tab} ${isActive ? styles.tabActive : ''}`}
+            aria-pressed={isActive}
+            onClick={() => onChange(type)}
+          >
+            {type === 'all' ? (
+              <IconFilterAll className={styles.tabGlyph} size={15} />
+            ) : (
+              <span
+                className={styles.tabIconWrap}
+                style={
+                  isThemeSurfaceIconProvider(type)
+                    ? { background: getThemeSurfaceIconBackground(resolvedTheme) }
+                    : undefined
+                }
+              >
+                {iconSrc ? (
+                  <img src={iconSrc} alt="" className={styles.tabIcon} />
+                ) : (
+                  <span className={styles.tabIconFallback}>
+                    {label.slice(0, 1).toUpperCase()}
+                  </span>
+                )}
+              </span>
+            )}
+            <span className={styles.tabLabel}>{label}</span>
+            <span className={styles.tabCount}>{counts[type] ?? 0}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1869,7 +1869,10 @@
   },
   "quota_management": {
     "title": "Quota Management",
-    "description": "Monitor OAuth quota status for Antigravity, Codex, and Gemini CLI credentials.",
+    "description": "Monitor OAuth quota status for Antigravity, Claude, Codex, Gemini CLI, Kimi, and xAI credentials.",
+    "meta_credentials": "{{count}} credentials",
+    "meta_loaded": "{{count}} loaded",
+    "meta_attention": "{{count}} need attention",
     "refresh_files": "Refresh auth files",
     "refresh_files_and_quota": "Refresh files & quota",
     "refresh_all_credentials": "Refresh all credentials",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -1864,7 +1864,10 @@
   },
   "quota_management": {
     "title": "Управление квотами",
-    "description": "Следите за статусом квот OAuth для учётных данных Antigravity, Codex и Gemini CLI.",
+    "description": "Следите за статусом квот OAuth для учётных данных Antigravity, Claude, Codex, Gemini CLI, Kimi и xAI.",
+    "meta_credentials": "{{count}} учётных данных",
+    "meta_loaded": "{{count}} загружено",
+    "meta_attention": "{{count}} требуют внимания",
     "refresh_files": "Обновить файлы авторизации",
     "refresh_files_and_quota": "Обновить файлы и квоты",
     "refresh_all_credentials": "Обновить все учётные данные",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1870,6 +1870,9 @@
   "quota_management": {
     "title": "配额管理",
     "description": "集中查看 OAuth 额度与剩余情况",
+    "meta_credentials": "{{count}} 个凭证",
+    "meta_loaded": "{{count}} 个已加载",
+    "meta_attention": "{{count}} 个需关注",
     "refresh_files": "刷新认证文件",
     "refresh_files_and_quota": "刷新认证文件&额度",
     "refresh_all_credentials": "刷新全部凭证",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1896,6 +1896,9 @@
   "quota_management": {
     "title": "配額管理",
     "description": "集中查看 OAuth 配額與剩餘情況",
+    "meta_credentials": "{{count}} 個憑證",
+    "meta_loaded": "{{count}} 個已載入",
+    "meta_attention": "{{count}} 個需關注",
     "refresh_files": "重新整理驗證檔案",
     "refresh_files_and_quota": "重新整理驗證檔案&配額",
     "refresh_all_credentials": "重新整理全部憑證",

--- a/src/pages/QuotaPage.module.scss
+++ b/src/pages/QuotaPage.module.scss
@@ -4,18 +4,23 @@
 .container {
   display: flex;
   flex-direction: column;
-  gap: $spacing-lg;
+  gap: 20px;
+  width: 100%;
+  min-width: 0;
 }
 
 .pageHeader {
   display: flex;
   flex-direction: column;
-  gap: $spacing-sm;
+  gap: 7px;
+  min-width: 0;
 }
 
 .pageTitle {
-  font-size: 28px;
+  font-size: clamp(26px, 3.2vw, 30px);
+  line-height: 1.15;
   font-weight: 700;
+  letter-spacing: -0.02em;
   color: var(--text-primary);
   margin: 0;
 }
@@ -24,6 +29,55 @@
   font-size: 14px;
   color: var(--text-secondary);
   margin: 0;
+  line-height: 1.55;
+}
+
+.pageMeta {
+  margin: 2px 0 0;
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 4px 8px;
+  font-family: $font-mono;
+  font-size: 13px;
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+  color: var(--text-secondary);
+
+  &::before {
+    content: '▍';
+    color: var(--viz-success, var(--success-color));
+    font-size: 13px;
+    line-height: 1;
+    align-self: center;
+    margin-right: 1px;
+  }
+}
+
+.metaDot {
+  color: var(--text-quaternary);
+  user-select: none;
+}
+
+.metaTotal {
+  color: var(--text-secondary);
+}
+
+.metaLoaded {
+  color: var(--viz-success, var(--success-color));
+}
+
+.metaMuted {
+  color: var(--text-tertiary);
+}
+
+.metaAttention {
+  color: var(--viz-failure, var(--danger-color));
+}
+
+.providerTabs {
+  min-width: 0;
 }
 
 .headerActions {
@@ -392,6 +446,99 @@
   }
 }
 
+.quotaIdleAction {
+  width: 100%;
+  min-height: 58px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px 14px;
+  border: 1px dashed color-mix(in srgb, var(--border-color) 86%, transparent);
+  border-radius: $radius-md;
+  background: color-mix(in srgb, var(--bg-secondary) 72%, transparent);
+  color: var(--text-tertiary);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  line-height: 1.45;
+  transition:
+    color $transition-fast,
+    border-color $transition-fast,
+    background-color $transition-fast;
+
+  &:hover:not(:disabled) {
+    color: var(--text-primary);
+    border-color: color-mix(in srgb, var(--primary-color) 42%, var(--border-color));
+    background: color-mix(in srgb, var(--primary-color) 7%, var(--bg-secondary));
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--primary-color);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.58;
+  }
+}
+
+.quotaSkeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 5px 0;
+}
+
+.quotaSkeletonRow {
+  display: grid;
+  grid-template-columns: minmax(76px, 0.34fr) minmax(120px, 1fr);
+  align-items: center;
+  gap: 12px;
+}
+
+.quotaSkeletonLabel,
+.quotaSkeletonTrack {
+  display: block;
+  height: 9px;
+  border-radius: $radius-full;
+  background-image: linear-gradient(
+    90deg,
+    var(--bg-tertiary) 0%,
+    color-mix(in srgb, var(--text-primary) 8%, var(--bg-tertiary)) 50%,
+    var(--bg-tertiary) 100%
+  );
+  background-size: 220% 100%;
+  animation: quota-skeleton-sweep 1.2s linear infinite;
+}
+
+.quotaSkeletonTrack {
+  height: 8px;
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@keyframes quota-skeleton-sweep {
+  from {
+    background-position: 100% 0;
+  }
+
+  to {
+    background-position: -100% 0;
+  }
+}
+
 .quotaCardActions {
   display: flex;
   justify-content: flex-end;
@@ -666,46 +813,84 @@
 
 .fileCard {
   background-color: var(--bg-primary);
-  border: 1px solid var(--border-color);
-  border-radius: $radius-lg;
-  padding: $spacing-md;
+  border: 1px solid color-mix(in srgb, var(--border-color) 92%, transparent);
+  border-radius: 14px;
+  padding: 16px;
   display: flex;
   flex-direction: column;
-  gap: $spacing-sm;
+  gap: 12px;
+  min-width: 0;
+  box-shadow: 0 1px 0 color-mix(in srgb, var(--text-primary) 4%, transparent);
   transition:
     transform $transition-fast,
     box-shadow $transition-fast,
     border-color $transition-fast;
+}
 
-  &:hover {
+@media (hover: hover) and (pointer: fine) {
+  .fileCard:hover {
     transform: translateY(-2px);
-    box-shadow: $shadow-md;
-    border-color: rgba(37, 99, 235, 0.2);
+    box-shadow: 0 14px 28px color-mix(in srgb, var(--text-primary) 10%, transparent);
+    border-color: color-mix(in srgb, var(--primary-color) 24%, var(--border-color));
   }
 }
 
 .cardHeader {
   display: flex;
   align-items: center;
-  gap: $spacing-sm;
-  min-height: 28px;
+  gap: 10px;
+  min-height: 34px;
+  min-width: 0;
 }
 
-.typeBadge {
-  padding: 4px 10px;
-  border-radius: 12px;
-  font-size: 12px;
-  font-weight: 600;
-  white-space: nowrap;
+.providerIconWrap {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--bg-tertiary) 88%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border-color) 82%, transparent);
   flex-shrink: 0;
 }
 
+.providerIcon {
+  width: 20px;
+  height: 20px;
+  object-fit: contain;
+  display: block;
+}
+
+.providerIconFallback {
+  font-size: 11px;
+  line-height: 1;
+  font-weight: 750;
+  color: var(--text-secondary);
+}
+
+.cardIdentity {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
 .fileName {
-  font-size: 14px;
-  font-weight: 600;
+  font-family: $font-mono;
+  font-size: 13px;
+  font-weight: 650;
   color: var(--text-primary);
-  word-break: break-all;
-  line-height: 1.4;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  line-height: 1.35;
+}
+
+.providerName {
+  font-size: 11px;
+  line-height: 1.25;
+  color: var(--text-tertiary);
 }
 
 .pagination {
@@ -752,5 +937,22 @@
     color: var(--text-primary);
     font-size: 14px;
     line-height: 1.6;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fileCard,
+  .quotaIdleAction,
+  .quotaBarFill {
+    transition: none;
+  }
+
+  .fileCard:hover {
+    transform: none;
+  }
+
+  .quotaSkeletonLabel,
+  .quotaSkeletonTrack {
+    animation: none;
   }
 }

--- a/src/pages/QuotaPage.tsx
+++ b/src/pages/QuotaPage.tsx
@@ -1,11 +1,12 @@
 /**
- * Quota management page - coordinates the three quota sections.
+ * Quota management page - coordinates the six LTS quota sections.
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHeaderRefresh } from '@/hooks/useHeaderRefresh';
-import { useAuthStore } from '@/stores';
+import { useCountUp, useRevealGroup } from '@/hooks/motion';
+import { useAuthStore, useQuotaStore, useThemeStore } from '@/stores';
 import { authFilesApi } from '@/services/api';
 import {
   QuotaSection,
@@ -16,16 +17,42 @@ import {
   KIMI_CONFIG,
   XAI_CONFIG,
 } from '@/components/quota';
+import { ProviderTabs } from '@/features/authFiles/components/ProviderTabs';
+import type { QuotaProviderType } from '@/features/authFiles/constants';
 import type { AuthFileItem } from '@/types';
 import styles from './QuotaPage.module.scss';
+
+type QuotaTabId = 'all' | QuotaProviderType;
+
+const QUOTA_PROVIDERS = [
+  { id: 'claude', config: CLAUDE_CONFIG },
+  { id: 'antigravity', config: ANTIGRAVITY_CONFIG },
+  { id: 'codex', config: CODEX_CONFIG },
+  { id: 'xai', config: XAI_CONFIG },
+  { id: 'gemini-cli', config: GEMINI_CLI_CONFIG },
+  { id: 'kimi', config: KIMI_CONFIG },
+] as const;
+
+const QUOTA_TAB_IDS: string[] = ['all', ...QUOTA_PROVIDERS.map(({ id }) => id)];
 
 export function QuotaPage() {
   const { t } = useTranslation();
   const connectionStatus = useAuthStore((state) => state.connectionStatus);
+  const resolvedTheme = useThemeStore((state) => state.resolvedTheme);
 
   const [files, setFiles] = useState<AuthFileItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+  const [activeProvider, setActiveProvider] = useState<QuotaTabId>('all');
+
+  const antigravityQuota = useQuotaStore((state) => state.antigravityQuota);
+  const claudeQuota = useQuotaStore((state) => state.claudeQuota);
+  const codexQuota = useQuotaStore((state) => state.codexQuota);
+  const geminiCliQuota = useQuotaStore((state) => state.geminiCliQuota);
+  const kimiQuota = useQuotaStore((state) => state.kimiQuota);
+  const xaiQuota = useQuotaStore((state) => state.xaiQuota);
+
+  const revealRef = useRevealGroup<HTMLDivElement>();
 
   const disableControls = connectionStatus !== 'connected';
 
@@ -49,51 +76,143 @@ export function QuotaPage() {
     loadFiles();
   }, [loadFiles]);
 
+  const providerCounts = useMemo(() => {
+    const counts: Record<string, number> = { all: 0 };
+    QUOTA_PROVIDERS.forEach(({ id, config }) => {
+      const count = files.filter((file) => config.filterFn(file)).length;
+      counts[id] = count;
+      counts.all += count;
+    });
+    return counts;
+  }, [files]);
+
+  const quotaByProvider = useMemo(
+    () => ({
+      antigravity: antigravityQuota,
+      claude: claudeQuota,
+      codex: codexQuota,
+      'gemini-cli': geminiCliQuota,
+      kimi: kimiQuota,
+      xai: xaiQuota,
+    }),
+    [antigravityQuota, claudeQuota, codexQuota, geminiCliQuota, kimiQuota, xaiQuota]
+  );
+
+  const { loadedCount, attentionCount } = useMemo(() => {
+    let loaded = 0;
+    let attention = 0;
+
+    QUOTA_PROVIDERS.forEach(({ id, config }) => {
+      files.filter((file) => config.filterFn(file)).forEach((file) => {
+        const status = quotaByProvider[id][file.name]?.status;
+        if (status === 'success') loaded += 1;
+        if (status === 'error') attention += 1;
+      });
+    });
+
+    return { loadedCount: loaded, attentionCount: attention };
+  }, [files, quotaByProvider]);
+
+  const displayLoadedCount = useCountUp(loadedCount);
+  const showProvider = (provider: QuotaProviderType) =>
+    activeProvider === 'all' || activeProvider === provider;
+
   return (
-    <div className={styles.container}>
-      <div className={styles.pageHeader}>
-        <h1 className={styles.pageTitle}>{t('quota_management.title')}</h1>
-        <p className={styles.description}>{t('quota_management.description')}</p>
+    <div className={styles.container} ref={revealRef}>
+      <header className={styles.pageHeader}>
+        <h1 className={styles.pageTitle} data-reveal>
+          {t('quota_management.title')}
+        </h1>
+        <p className={styles.description} data-reveal>
+          {t('quota_management.description')}
+        </p>
+        <p className={styles.pageMeta} data-reveal>
+          <span className={styles.metaTotal}>
+            {t('quota_management.meta_credentials', { count: providerCounts.all })}
+          </span>
+          <span className={styles.metaDot} aria-hidden="true">
+            ·
+          </span>
+          <span className={loadedCount > 0 ? styles.metaLoaded : styles.metaMuted}>
+            {t('quota_management.meta_loaded', { count: displayLoadedCount })}
+          </span>
+          {attentionCount > 0 && (
+            <>
+              <span className={styles.metaDot} aria-hidden="true">
+                ·
+              </span>
+              <span className={styles.metaAttention}>
+                {t('quota_management.meta_attention', { count: attentionCount })}
+              </span>
+            </>
+          )}
+        </p>
+      </header>
+
+      <div className={styles.providerTabs} data-reveal>
+        <ProviderTabs
+          types={QUOTA_TAB_IDS}
+          counts={providerCounts}
+          active={activeProvider}
+          resolvedTheme={resolvedTheme}
+          onChange={(provider) => setActiveProvider(provider as QuotaTabId)}
+        />
       </div>
 
-      {error && <div className={styles.errorBox}>{error}</div>}
+      {error && (
+        <div className={styles.errorBox} role="alert">
+          {error}
+        </div>
+      )}
 
-      <QuotaSection
-        config={CLAUDE_CONFIG}
-        files={files}
-        loading={loading}
-        disabled={disableControls}
-      />
-      <QuotaSection
-        config={ANTIGRAVITY_CONFIG}
-        files={files}
-        loading={loading}
-        disabled={disableControls}
-      />
-      <QuotaSection
-        config={CODEX_CONFIG}
-        files={files}
-        loading={loading}
-        disabled={disableControls}
-      />
-      <QuotaSection
-        config={XAI_CONFIG}
-        files={files}
-        loading={loading}
-        disabled={disableControls}
-      />
-      <QuotaSection
-        config={GEMINI_CLI_CONFIG}
-        files={files}
-        loading={loading}
-        disabled={disableControls}
-      />
-      <QuotaSection
-        config={KIMI_CONFIG}
-        files={files}
-        loading={loading}
-        disabled={disableControls}
-      />
+      <div hidden={!showProvider('claude')}>
+        <QuotaSection
+          config={CLAUDE_CONFIG}
+          files={files}
+          loading={loading}
+          disabled={disableControls}
+        />
+      </div>
+      <div hidden={!showProvider('antigravity')}>
+        <QuotaSection
+          config={ANTIGRAVITY_CONFIG}
+          files={files}
+          loading={loading}
+          disabled={disableControls}
+        />
+      </div>
+      <div hidden={!showProvider('codex')}>
+        <QuotaSection
+          config={CODEX_CONFIG}
+          files={files}
+          loading={loading}
+          disabled={disableControls}
+        />
+      </div>
+      <div hidden={!showProvider('xai')}>
+        <QuotaSection
+          config={XAI_CONFIG}
+          files={files}
+          loading={loading}
+          disabled={disableControls}
+        />
+      </div>
+      <div hidden={!showProvider('gemini-cli')}>
+        <QuotaSection
+          config={GEMINI_CLI_CONFIG}
+          files={files}
+          loading={loading}
+          disabled={disableControls}
+        />
+      </div>
+      <div hidden={!showProvider('kimi')}>
+        <QuotaSection
+          config={KIMI_CONFIG}
+          files={files}
+          loading={loading}
+          disabled={disableControls}
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## 背景

截至 2026-08-09，上游最新 release 为 `v1.22.2`（`f60c8ca`）。上游 quota 已演进为统一 tabs/grid/timeline 工作台，但 LTS 仍需保留完整 usage UI、Gemini CLI 和 Codex sidecar，因此本 PR 只做低风险视觉适配，不整体替换 quota 实现。

## 改动

- 增加 `All / Claude / Antigravity / Codex / xAI / Gemini CLI / Kimi` provider tabs 与凭证数量。
- 增加总凭证、已加载、需关注的页面摘要。
- quota 卡片使用 provider icon、mono 文件名、provider 副标题、idle 操作面、loading skeleton 和可访问的 error alert。
- tab 切换通过 `hidden` 保持六个原有 `QuotaSection` 挂载，保留分页、view mode 与已加载 quota 状态。
- 补齐桌面、移动端、hover、focus-visible 与 reduced-motion 样式。

## LTS 保留边界

- 六个 provider 全部保留，包括 Gemini CLI。
- Codex analytics、Team fallback、`Est weekly 0.31 USD`、reset-credit details 与双重危险确认保持不变。
- Codex `batchConcurrency=1` / `batchDelayMs=600` 保持不变。
- 未修改 quota fetch/parser/store/loader、Management API、Core contract、`src/lts/`、完整 usage 统计链或 release workflow。

## 明确不在本 PR

- quota timeline 与上游 reset-window 数据语义。
- AuthFiles Vault、Config rewrite。
- Infistar/affiliate provider。
- Antigravity project/subscription/server-time 与 xAI paid-health 等行为切片。

## 验证

- `npm run validate:lts`
- `npm run test:quota`（14/14）
- `npm run smoke:lts`
- `git diff --check`
- 本地 mock Core 浏览器验收：桌面与 `390×844` 移动端；tabs 横向滚动、卡片单列、根页面无横向溢出；切回 All 后 Codex 已加载状态仍保留；reset-credit 双重确认走到最终动作前取消；浏览器 console 无 warning/error。