### PR TITLE
fix(release): 要求显式 LTS 摘要与配套版本

### DIFF
--- a/.github/workflows/lts-panel-contract.yml
+++ b/.github/workflows/lts-panel-contract.yml
@@ -14,6 +14,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
+      - name: Test release notes contract
+        run: scripts/generate-lts-release-notes_test.sh
+
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,16 @@ on:
         description: 'Release tag to build and publish, for example v1-tls-0.0.1'
         required: true
         type: string
+      rewrite_release_notes:
+        description: 'Replace the title and notes when the Release already exists'
+        required: false
+        default: false
+        type: boolean
+
+env:
+  GH_REPO: ${{ github.repository }}
+  RELEASE_TAG: ${{ github.event.inputs.release_tag || github.ref_name }}
+  REWRITE_RELEASE_NOTES: ${{ github.event_name == 'workflow_dispatch' && inputs.rewrite_release_notes || false }}
 
 jobs:
   build-and-release:
@@ -49,35 +59,51 @@ jobs:
       - name: Generate release notes
         run: |
           set -euo pipefail
-          current_tag="${RELEASE_TAG:-${GITHUB_REF_NAME}}"
-          if [[ "${current_tag}" != v*-tls-* ]]; then
+          if [[ "${RELEASE_TAG}" != v*-tls-* ]]; then
             echo "Only panel release tags matching v*-tls-* are supported."
             exit 1
           fi
-          if ! git rev-parse -q --verify "refs/tags/${current_tag}" >/dev/null; then
-            echo "Release tag ${current_tag} does not exist."
+          if ! git rev-parse -q --verify "refs/tags/${RELEASE_TAG}" >/dev/null; then
+            echo "Release tag ${RELEASE_TAG} does not exist."
             exit 1
           fi
 
+          release_exists=false
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            release_exists=true
+          fi
+          echo "RELEASE_EXISTS=${release_exists}" >> "$GITHUB_ENV"
+          if [[ "$release_exists" == "true" && "$REWRITE_RELEASE_NOTES" != "true" ]]; then
+            echo "Release ${RELEASE_TAG} already exists; preserving its title and notes."
+            echo "RELEASE_NOTES_READY=false" >> "$GITHUB_ENV"
+            exit 0
+          fi
+
           bash scripts/generate-lts-release-notes.sh \
-            --product panel \
-            --tag "${current_tag}" \
+            --tag "${RELEASE_TAG}" \
             --notes-file release-notes.md \
             --title-file release-title.txt
           echo "RELEASE_TITLE=$(tr -d '\n' < release-title.txt)" >> "$GITHUB_ENV"
-        env:
-          RELEASE_TAG: ${{ github.event.inputs.release_tag || github.ref_name }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          echo "RELEASE_NOTES_READY=true" >> "$GITHUB_ENV"
 
-      - name: Create Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ github.event.inputs.release_tag || github.ref_name }}
-          name: ${{ env.RELEASE_TITLE }}
-          files: |
-            dist/management.html
-          body_path: release-notes.md
-          draft: false
-          prerelease: false
+      - name: Publish release and management.html
+        run: |
+          set -euo pipefail
+          if [[ "$RELEASE_EXISTS" == "true" ]]; then
+            if [[ "$RELEASE_NOTES_READY" == "true" ]]; then
+              gh release edit "$RELEASE_TAG" \
+                --title "$RELEASE_TITLE" \
+                --notes-file release-notes.md
+            fi
+            gh release upload "$RELEASE_TAG" dist/management.html --clobber
+          else
+            if [[ "$RELEASE_NOTES_READY" != "true" ]]; then
+              echo "Release notes are required when creating ${RELEASE_TAG}." >&2
+              exit 1
+            fi
+            gh release create "$RELEASE_TAG" dist/management.html \
+              --title "$RELEASE_TITLE" \
+              --notes-file release-notes.md
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ The UI language is automatically detected from browser settings and can be manua
 
 - Vite produces a **single HTML** output (`dist/index.html`) with all assets inlined (via `vite-plugin-singlefile`).
 - Tagging a panel release such as `v1-tls-0.0.1` triggers `.github/workflows/release.yml` to publish `dist/management.html`.
-- Use an annotated tag whose message is the human summary. The workflow turns that message, first-parent LTS PRs, the companion Core release, and GitHub `generate-notes` into the Release body; do not rely on a raw `git log` dump.
+- Use an annotated tag whose subject is the human summary and whose body contains exactly one `Companion-Core: v*-tls-*` line. The workflow uses that explicit contract plus GitHub `generate-notes`; it does not infer compatibility from release timestamps or PR order.
 - Push only the exact panel release tag being released; do not use `git push --tags` after fetching upstream.
 - The UI version shown in the footer is injected at build time (env `VERSION`, git tag, or `package.json` fallback).
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -155,7 +155,7 @@ npm run build
 
 - 使用 Vite 输出 **单文件 HTML**（`dist/index.html`），资源全部内联（`vite-plugin-singlefile`）。
 - 打 `v1-tls-0.0.1` 这类面板发布标签会触发 `.github/workflows/release.yml`，发布 `dist/management.html`。
-- 使用 annotated tag，并在 tag message 里写清本版摘要。工作流会用这条摘要、first-parent LTS PR、配套 Core 版本和 GitHub `generate-notes` 生成 Release 正文，不再倒原始 `git log`。
+- 使用 annotated tag：subject 写本版摘要，body 必须且只能包含一条 `Companion-Core: v*-tls-*`。工作流使用这份显式契约和 GitHub `generate-notes`，不再按发布时间或 PR 顺序推断兼容关系。
 - 发布时只推送当前面板发布标签；跟进上游后不要使用 `git push --tags`。
 - 页脚显示的 UI 版本在构建期注入（优先使用环境变量 `VERSION`，否则使用 git tag / `package.json`）。
 

--- a/docs/lts/sync-runbook.md
+++ b/docs/lts/sync-runbook.md
@@ -387,7 +387,8 @@ When releasing:
 2. Run `npm run type-check`.
 3. Run `npm run lint`.
 4. Run `npm run build`.
-5. Create an annotated `v*-tls-*` tag whose message is the user-facing summary, including the companion Core tag when known. Do not use a lightweight tag or a message that only repeats the version.
+5. Create an annotated `v*-tls-*` tag. Its subject is the user-facing summary and its body must contain exactly one `Companion-Core: v*-tls-*` line. Do not use a lightweight tag, a placeholder summary, or release-time proximity as a compatibility signal.
 6. Push only the exact intended tag, for example `v1-tls-0.0.3`.
 7. Confirm `.github/workflows/release.yml` wrote the Release body via `scripts/generate-lts-release-notes.sh` and that the GitHub release contains `management.html`.
-8. Read the published notes and confirm they show the summary, companion Core release, first-parent highlights, and `management.html` asset — not a raw commit dump.
+8. Read the published notes and confirm they show the tag summary, explicitly declared companion Core release, and `management.html` asset — not a raw commit dump.
+9. A manual dispatch for an existing Release preserves its title and body by default. Enable `rewrite_release_notes` only when replacing those fields is intentional.

--- a/scripts/generate-lts-release-notes.sh
+++ b/scripts/generate-lts-release-notes.sh
@@ -1,36 +1,41 @@
 #!/usr/bin/env bash
-# Generate scannable GitHub release notes for a CPA LTS tag.
-# Previous TLS tag discovery only considers v*-tls-* refs, never upstream v7.* / v1.8.* tags.
+# Generate a CPA-Panel-LTS Release body from an authoritative annotated tag.
 set -euo pipefail
+
+DEFAULT_REPO="BlueSkyXN/CPA-Panel-LTS"
+COMPANION_LABEL="CPA-Core-LTS"
+DEFAULT_COMPANION_REPO="BlueSkyXN/CPA-Core-LTS"
+COMPANION_TRAILER="Companion-Core"
 
 usage() {
   cat <<'EOF'
-Usage: scripts/generate-lts-release-notes.sh --product core|panel --tag v1-tls-X.Y.Z [options]
+Usage: scripts/generate-lts-release-notes.sh --tag v1-tls-X.Y.Z [options]
+
+The tag must be annotated. Its subject is the user-facing summary and its body
+must contain exactly one companion trailer, for example:
+
+  Panel LTS: upstream intake and retained LTS fixes
+
+  Companion-Core: v1-tls-0.0.20
 
 Options:
-  --product core|panel   Required. Selects companion repo and asset section.
-  --tag TAG              Required. Existing v*-tls-* tag.
-  --repo OWNER/NAME      Override GitHub repo. Defaults from --product.
-  --companion OWNER/NAME Override companion repo. Defaults from --product.
-  --notes-file PATH      Write notes to PATH instead of stdout.
-  --title-file PATH      Write the release title to PATH.
-  -h, --help             Show this help.
+  --tag TAG                   Required. Existing annotated v*-tls-* tag.
+  --repo OWNER/NAME           Override the Panel repository.
+  --companion-repo OWNER/NAME Override the Core repository.
+  --notes-file PATH           Write notes to PATH instead of stdout.
+  --title-file PATH           Write the release title to PATH.
+  -h, --help                  Show this help.
 EOF
 }
 
-product=""
 tag=""
-repo=""
-companion=""
+repo="${GH_REPO:-$DEFAULT_REPO}"
+companion_repo="$DEFAULT_COMPANION_REPO"
 notes_file=""
 title_file=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --product)
-      product="${2:-}"
-      shift 2
-      ;;
     --tag)
       tag="${2:-}"
       shift 2
@@ -39,8 +44,8 @@ while [[ $# -gt 0 ]]; do
       repo="${2:-}"
       shift 2
       ;;
-    --companion)
-      companion="${2:-}"
+    --companion-repo)
+      companion_repo="${2:-}"
       shift 2
       ;;
     --notes-file)
@@ -63,40 +68,62 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ -z "$product" || -z "$tag" ]]; then
-  echo "--product and --tag are required" >&2
+if [[ -z "$tag" ]]; then
+  echo "--tag is required" >&2
   usage >&2
   exit 2
 fi
 
-case "$product" in
-  core)
-    repo="${repo:-${GH_REPO:-BlueSkyXN/CPA-Core-LTS}}"
-    companion="${companion:-BlueSkyXN/CPA-Panel-LTS}"
-    companion_label="CPA-Panel-LTS"
-    ;;
-  panel)
-    repo="${repo:-${GH_REPO:-BlueSkyXN/CPA-Panel-LTS}}"
-    companion="${companion:-BlueSkyXN/CPA-Core-LTS}"
-    companion_label="CPA-Core-LTS"
-    ;;
-  *)
-    echo "--product must be core or panel" >&2
-    exit 2
-    ;;
-esac
-
-SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
-REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)
 cd "$REPO_ROOT"
 
 if [[ "$tag" != v*-tls-* ]]; then
-  echo "Only LTS release tags matching v*-tls-* are supported: $tag" >&2
+  echo "Only Panel LTS release tags matching v*-tls-* are supported: $tag" >&2
   exit 1
 fi
 
-if ! git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+tag_ref="refs/tags/${tag}"
+if ! git rev-parse -q --verify "$tag_ref" >/dev/null; then
   echo "Release tag ${tag} does not exist in this checkout." >&2
+  exit 1
+fi
+if [[ "$(git cat-file -t "$tag_ref" 2>/dev/null || true)" != "tag" ]]; then
+  echo "Release tag ${tag} must be an annotated tag." >&2
+  exit 1
+fi
+
+tag_message="$(git for-each-ref --format='%(contents)' "$tag_ref")"
+summary="$(git for-each-ref --format='%(contents:subject)' "$tag_ref" | sed -n '1p')"
+
+is_placeholder_summary() {
+  local candidate="$1"
+  local current="$2"
+  local compact tag_compact
+  compact="$(printf '%s' "$candidate" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:][:punct:]')"
+  tag_compact="$(printf '%s' "$current" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:][:punct:]')"
+  [[ -z "$compact" || "$compact" == "$tag_compact" || \
+    ( ${#candidate} -le 48 && "$compact" == *"$tag_compact"* ) ]]
+}
+
+if is_placeholder_summary "$summary" "$tag"; then
+  echo "Release tag ${tag} must contain a meaningful user-facing summary." >&2
+  exit 1
+fi
+
+companion_lines="$(
+  printf '%s\n' "$tag_message" |
+    sed -n "s/^${COMPANION_TRAILER}:[[:space:]]*//p" |
+    sed 's/[[:space:]]*$//'
+)"
+companion_count="$(printf '%s\n' "$companion_lines" | awk 'NF { count++ } END { print count + 0 }')"
+if [[ "$companion_count" -ne 1 ]]; then
+  echo "Release tag ${tag} must contain exactly one ${COMPANION_TRAILER}: v*-tls-* trailer." >&2
+  exit 1
+fi
+companion_tag="$(printf '%s\n' "$companion_lines" | sed -n '1p')"
+if [[ "$companion_tag" != v*-tls-* ]]; then
+  echo "${COMPANION_TRAILER} value must match v*-tls-*: ${companion_tag}" >&2
   exit 1
 fi
 
@@ -113,203 +140,35 @@ previous_tls_tag() {
   return 1
 }
 
-tag_subject() {
-  local current="$1"
-  local subject
-  subject="$(git tag --list --format='%(contents:subject)' "$current" | sed -n '1p')"
-  printf '%s' "$subject"
-}
-
-is_placeholder_subject() {
-  local subject="$1"
-  local current="$2"
-  local compact tagcompact
-  compact="$(printf '%s' "$subject" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:][:punct:]')"
-  tagcompact="$(printf '%s' "$current" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:][:punct:]')"
-  if [[ -z "$compact" ]]; then
-    return 0
-  fi
-  if [[ "$compact" == "$tagcompact" ]]; then
-    return 0
-  fi
-  if [[ ${#subject} -le 48 && "$compact" == *"$tagcompact"* ]]; then
-    return 0
-  fi
-  return 1
-}
-
-brief_first_parent_line() {
-  local subject="$1"
-  local pr rest
-  if [[ "$subject" == "Merge pull request #"* ]]; then
-    pr="$(printf '%s' "$subject" | sed -n 's/^Merge pull request \(#[0-9][0-9]*\).*/\1/p')"
-    rest="$(printf '%s' "$subject" | sed -n 's/^Merge pull request #[0-9][0-9]* from [^/]*\///p')"
-    if [[ -n "$pr" && -n "$rest" ]]; then
-      printf '%s — %s\n' "$pr" "$rest"
-      return 0
-    fi
-  fi
-  printf '%s\n' "$subject"
-}
-
-iso_from_tag() {
-  local current="$1"
-  git for-each-ref --format='%(creatordate:iso-strict)' "refs/tags/${current}" | sed -n '1p'
-}
-
-normalize_iso() {
-  local raw="$1"
-  python3 -c 'import sys
-from datetime import datetime, timezone
-raw = sys.argv[1].strip()
-if not raw:
-    raise SystemExit(1)
-text = raw.replace("Z", "+00:00")
-dt = datetime.fromisoformat(text)
-if dt.tzinfo is None:
-    dt = dt.replace(tzinfo=timezone.utc)
-print(dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"))
-' "$raw"
-}
-
-companion_choice() {
-  local companion_repo="$1"
-  local current_iso="$2"
-  if [[ -z "$current_iso" ]]; then
-    return 1
-  fi
-  if ! command -v gh >/dev/null 2>&1; then
-    return 1
-  fi
-  local payload
-  if ! payload="$(gh release list --repo "$companion_repo" --limit 30 --json tagName,publishedAt 2>/dev/null)"; then
-    return 1
-  fi
-  python3 -c 'import json, sys
-from datetime import datetime, timezone
-
-def parse(value):
-    text = value.replace("Z", "+00:00")
-    dt = datetime.fromisoformat(text)
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-    return dt.astimezone(timezone.utc)
-
-current = parse(sys.argv[1])
-releases = json.loads(sys.argv[2])
-eligible = []
-for item in releases:
-    published = item.get("publishedAt") or ""
-    tag_name = item.get("tagName") or ""
-    if not published or not tag_name:
-        continue
-    dt = parse(published)
-    if dt.timestamp() <= current.timestamp() + 7200:
-        eligible.append((dt, tag_name, published))
-if not eligible:
-    raise SystemExit(1)
-eligible.sort(key=lambda row: row[0], reverse=True)
-chosen = eligible[0]
-delta = abs((chosen[0] - current).total_seconds())
-kind = "paired" if delta <= 36 * 3600 else "latest"
-print(f"{chosen[1]}\t{kind}\t{chosen[2]}")
-' "$current_iso" "$payload"
-}
-
-core_asset_section() {
-  cat <<'EOF'
-<!-- cliproxyapi-linux-release-assets:start -->
-## 发布资产
-
-- `CLIProxyAPI_<version>_linux_<arch>.tar.gz` 是默认 Linux 构建，支持动态库插件，GLIBC 基线为 2.17。
-- `CLIProxyAPI_<version>_linux_<arch>_no-plugin.tar.gz` 是面向 musl / OpenWrt 等环境的便携构建，不支持动态库插件。
-- `sky-cpa-core-lts_<version>_linux_<arch>.tar.gz` 与 `sky-cpa-core-lts_<version>_linux_<arch>_no-plugin.tar.gz` 使用同一套 Core 代码和平台矩阵，只是二进制名和产品横幅为 `sky-cpa-core-lts`，供 CPA-HFS 使用。
-
-### FreeBSD
-
-- `CLIProxyAPI_<version>_freebsd_aarch64_no-plugin.tar.gz` 是 FreeBSD arm64 构建，关闭 CGO，不支持动态库插件。
-
-<!-- cliproxyapi-linux-release-assets:end -->
-EOF
-}
-
-panel_asset_section() {
-  cat <<'EOF'
-## 发布资产
-
-- `management.html`：单文件管理面板，供 `CPA-Core-LTS` 按资产名下载。
-EOF
-}
-
 previous=""
 if previous="$(previous_tls_tag "$tag")"; then
-  range="${previous}..${tag}"
+  :
 else
   previous=""
-  range="$tag"
 fi
 
-subject="$(tag_subject "$tag")"
-highlights_file="$(mktemp)"
-briefs_file="$(mktemp)"
 generated_file="$(mktemp)"
-trap 'rm -f "$highlights_file" "$briefs_file" "$generated_file"' EXIT
-
-if [[ -n "$previous" ]]; then
-  git log --first-parent --reverse --pretty=format:'%s' "$range" > "$highlights_file" || true
-else
-  : > "$highlights_file"
-fi
-
-while IFS= read -r line || [[ -n "${line:-}" ]]; do
-  [[ -z "$line" ]] && continue
-  brief_first_parent_line "$line" >> "$briefs_file"
-done < "$highlights_file"
+notes_tmp="$(mktemp)"
+trap 'rm -f "$generated_file" "$notes_tmp"' EXIT
 
 if command -v gh >/dev/null 2>&1; then
   generate_args=(api "repos/${repo}/releases/generate-notes" -f "tag_name=${tag}")
   if [[ -n "$previous" ]]; then
     generate_args+=(-f "previous_tag_name=${previous}")
   fi
-  gh "${generate_args[@]}" --jq .body > "$generated_file" 2>/dev/null || true
+  gh "${generate_args[@]}" --jq .body >"$generated_file" 2>/dev/null || true
 fi
 if [[ ! -s "$generated_file" ]]; then
   if [[ -n "$previous" ]]; then
-    printf '**完整变更**: https://github.com/%s/compare/%s...%s\n' "$repo" "$previous" "$tag" > "$generated_file"
+    printf '**完整变更**: https://github.com/%s/compare/%s...%s\n' \
+      "$repo" "$previous" "$tag" >"$generated_file"
   else
-    printf '**完整变更**: https://github.com/%s/commits/%s\n' "$repo" "$tag" > "$generated_file"
+    printf '**完整变更**: https://github.com/%s/commits/%s\n' \
+      "$repo" "$tag" >"$generated_file"
   fi
 fi
 
-summary_from_generated_notes() {
-  python3 -c 'import re, sys
-text = sys.stdin.read()
-titles = []
-for line in text.splitlines():
-    match = re.match(r"^\* (.+?) by @", line)
-    if match:
-        titles.append(match.group(1).strip())
-print("；".join(titles[:3]))
-'
-}
-
-summary="$subject"
-if is_placeholder_subject "$subject" "$tag"; then
-  summary=""
-  if [[ -s "$generated_file" ]]; then
-    summary="$(summary_from_generated_notes < "$generated_file")"
-  fi
-  if [[ -z "$summary" && -s "$briefs_file" ]]; then
-    summary="$(sed -n '1,3p' "$briefs_file" | paste -sd '；' -)"
-  fi
-fi
-if [[ -z "$summary" ]]; then
-  summary="${tag}"
-fi
-
-title="$tag"
-if [[ "$summary" != "$tag" ]]; then
-  short_summary="$(printf '%s' "$summary" | python3 -c 'import sys
+short_summary="$(printf '%s' "$summary" | python3 -c 'import sys
 text = sys.stdin.read().strip()
 limit = 140
 if len(text) <= limit:
@@ -317,80 +176,35 @@ if len(text) <= limit:
     raise SystemExit
 cut = text[:limit]
 for sep in ("；", ";", ",", "，", " "):
-    idx = cut.rfind(sep)
-    if idx >= 48:
-        cut = cut[:idx].rstrip("；;,， ")
+    index = cut.rfind(sep)
+    if index >= 48:
+        cut = cut[:index].rstrip("；;,， ")
         break
 print(cut + "...")
 ')"
-  title="${tag} — ${short_summary}"
-fi
+title="${tag} — ${short_summary}"
 
-current_iso=""
-if raw_iso="$(iso_from_tag "$tag")"; then
-  current_iso="$(normalize_iso "$raw_iso" || true)"
-fi
-if [[ -z "$current_iso" ]] && command -v gh >/dev/null 2>&1; then
-  published="$(gh release view "$tag" --repo "$repo" --json publishedAt --jq .publishedAt 2>/dev/null || true)"
-  if [[ -n "$published" ]]; then
-    current_iso="$(normalize_iso "$published" || true)"
-  fi
-fi
-
-companion_tag=""
-companion_kind=""
-if companion_row="$(companion_choice "$companion" "$current_iso" 2>/dev/null)"; then
-  companion_tag="$(printf '%s' "$companion_row" | awk -F '\t' 'NR==1{print $1}')"
-  companion_kind="$(printf '%s' "$companion_row" | awk -F '\t' 'NR==1{print $2}')"
-fi
-
-notes_tmp="$(mktemp)"
 {
   printf '## 摘要\n\n%s\n\n' "$summary"
-
   printf '## 配套版本\n\n'
-  if [[ -n "$companion_tag" ]]; then
-    if [[ "$companion_kind" == "paired" ]]; then
-      printf -- '- 同期配套 %s：[%s](https://github.com/%s/releases/tag/%s)\n\n' \
-        "$companion_label" "$companion_tag" "$companion" "$companion_tag"
-    else
-      printf -- '- 发布时可用的 %s Latest：[%s](https://github.com/%s/releases/tag/%s)\n\n' \
-        "$companion_label" "$companion_tag" "$companion" "$companion_tag"
-    fi
-  else
-    printf -- '- 配套 %s：未能从 GitHub 解析同期 Release，请按发布当天的 Latest 核对。\n\n' "$companion_label"
-  fi
+  printf -- '- 配套 %s：[%s](https://github.com/%s/releases/tag/%s)\n\n' \
+    "$COMPANION_LABEL" "$companion_tag" "$companion_repo" "$companion_tag"
 
-  printf '## 本版要点\n\n'
-  if [[ -s "$briefs_file" ]]; then
-    while IFS= read -r brief || [[ -n "${brief:-}" ]]; do
-      [[ -z "$brief" ]] && continue
-      printf -- '- %s\n' "$brief"
-    done < "$briefs_file"
-    printf '\n'
-  else
-    printf -- '- 本 tag 没有可列出的 first-parent 变更。\n\n'
-  fi
+  cat <<'EOF'
+## 发布资产
 
-  if [[ "$product" == "core" ]]; then
-    core_asset_section
-    printf '\n'
-  else
-    panel_asset_section
-    printf '\n'
-  fi
+- `management.html`：单文件管理面板，供 `CPA-Core-LTS` 按资产名下载。
 
+EOF
   cat "$generated_file"
   printf '\n'
-} > "$notes_tmp"
+} >"$notes_tmp"
 
 if [[ -n "$title_file" ]]; then
-  printf '%s\n' "$title" > "$title_file"
+  printf '%s\n' "$title" >"$title_file"
 fi
-
 if [[ -n "$notes_file" ]]; then
-  cat "$notes_tmp" > "$notes_file"
+  cat "$notes_tmp" >"$notes_file"
 else
   cat "$notes_tmp"
 fi
-rm -f "$notes_tmp"

--- a/scripts/generate-lts-release-notes_test.sh
+++ b/scripts/generate-lts-release-notes_test.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+GENERATOR="$ROOT_DIR/scripts/generate-lts-release-notes.sh"
+
+fail() {
+  printf 'release notes generator test failed: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+  if ! grep -Fq -- "$expected" "$file"; then
+    printf 'expected %s to contain: %s\n' "$file" "$expected" >&2
+    sed -n '1,120p' "$file" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local file="$1"
+  local unexpected="$2"
+  if grep -Fq -- "$unexpected" "$file"; then
+    printf 'expected %s not to contain: %s\n' "$file" "$unexpected" >&2
+    sed -n '1,120p' "$file" >&2
+    exit 1
+  fi
+}
+
+expect_failure() {
+  local expected="$1"
+  local tag="$2"
+  local stdout_file="$FIXTURE_DIR/stdout"
+  local stderr_file="$FIXTURE_DIR/stderr"
+
+  if PATH="$MOCK_BIN:$PATH" GH_MOCK_LOG="$GH_MOCK_LOG" \
+    bash "$FIXTURE_DIR/repo/scripts/generate-lts-release-notes.sh" \
+      --tag "$tag" >"$stdout_file" 2>"$stderr_file"; then
+    fail "$tag unexpectedly succeeded"
+  fi
+  assert_contains "$stderr_file" "$expected"
+}
+
+FIXTURE_DIR=$(mktemp -d)
+trap 'rm -rf "$FIXTURE_DIR"' EXIT
+MOCK_BIN="$FIXTURE_DIR/bin"
+GH_MOCK_LOG="$FIXTURE_DIR/gh.log"
+mkdir -p "$FIXTURE_DIR/repo/scripts" "$MOCK_BIN"
+cp "$GENERATOR" "$FIXTURE_DIR/repo/scripts/"
+
+cat >"$MOCK_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${GH_MOCK_LOG:?}"
+if [[ "${1:-}" == "api" ]]; then
+  if [[ "${GH_MOCK_FAIL:-false}" == "true" ]]; then
+    exit 1
+  fi
+  cat <<'NOTES'
+## What's Changed
+* fix(panel): keep the final behavior by @maintainer in https://example.invalid/pull/1
+
+**Full Changelog**: https://example.invalid/compare
+NOTES
+  exit 0
+fi
+exit 1
+EOF
+chmod +x "$MOCK_BIN/gh"
+
+cd "$FIXTURE_DIR/repo"
+git init -q
+git config user.name fixture
+git config user.email fixture@example.invalid
+
+printf 'base\n' >fixture.txt
+git add fixture.txt
+git commit -qm base
+git tag -a v1-tls-0.0.1 \
+  -m 'Panel LTS: base release' \
+  -m 'Companion-Core: v1-tls-0.0.1'
+
+printf 'upstream\n' >>fixture.txt
+git commit -qam upstream
+git tag -a v1.99.0 -m 'upstream v1.99.0'
+
+printf 'release\n' >>fixture.txt
+git commit -qam release
+git tag -a v1-tls-0.0.2 \
+  -m 'Panel LTS: explicit summary survives release ordering' \
+  -m 'Companion-Core: v1-tls-0.0.2'
+
+output_file="$FIXTURE_DIR/release-notes.md"
+title_file="$FIXTURE_DIR/release-title.txt"
+PATH="$MOCK_BIN:$PATH" GH_MOCK_LOG="$GH_MOCK_LOG" \
+  bash scripts/generate-lts-release-notes.sh \
+    --tag v1-tls-0.0.2 \
+    --notes-file "$output_file" \
+    --title-file "$title_file"
+
+assert_contains "$output_file" 'Panel LTS: explicit summary survives release ordering'
+assert_contains "$output_file" 'CPA-Core-LTS：[v1-tls-0.0.2]'
+assert_contains "$output_file" '## What'"'"'s Changed'
+assert_not_contains "$output_file" '## 本版要点'
+assert_contains "$title_file" 'v1-tls-0.0.2 — Panel LTS: explicit summary survives release ordering'
+assert_contains "$GH_MOCK_LOG" 'previous_tag_name=v1-tls-0.0.1'
+assert_not_contains "$GH_MOCK_LOG" 'previous_tag_name=v1.99.0'
+
+fallback_file="$FIXTURE_DIR/release-notes-fallback.md"
+PATH="$MOCK_BIN:$PATH" GH_MOCK_LOG="$GH_MOCK_LOG" GH_MOCK_FAIL=true \
+  bash scripts/generate-lts-release-notes.sh \
+    --tag v1-tls-0.0.2 \
+    --notes-file "$fallback_file"
+assert_contains "$fallback_file" 'Panel LTS: explicit summary survives release ordering'
+assert_contains "$fallback_file" 'CPA-Panel-LTS/compare/v1-tls-0.0.1...v1-tls-0.0.2'
+
+printf 'lightweight\n' >>fixture.txt
+git commit -qam lightweight
+git tag v1-tls-0.0.3
+expect_failure 'must be an annotated tag' v1-tls-0.0.3
+
+printf 'placeholder\n' >>fixture.txt
+git commit -qam placeholder
+git tag -a v1-tls-0.0.4 \
+  -m 'CPA Panel LTS v1-tls-0.0.4' \
+  -m 'Companion-Core: v1-tls-0.0.4'
+expect_failure 'meaningful user-facing summary' v1-tls-0.0.4
+
+printf 'missing companion\n' >>fixture.txt
+git commit -qam missing-companion
+git tag -a v1-tls-0.0.5 -m 'Panel LTS: missing companion fixture'
+expect_failure 'Companion-Core' v1-tls-0.0.5
+
+printf 'invalid companion\n' >>fixture.txt
+git commit -qam invalid-companion
+git tag -a v1-tls-0.0.6 \
+  -m 'Panel LTS: invalid companion fixture' \
+  -m 'Companion-Core: core-latest'
+expect_failure 'must match v*-tls-*' v1-tls-0.0.6
+
+printf 'duplicate companion\n' >>fixture.txt
+git commit -qam duplicate-companion
+git tag -a v1-tls-0.0.7 \
+  -m 'Panel LTS: duplicate companion fixture' \
+  -m $'Companion-Core: v1-tls-0.0.6\nCompanion-Core: v1-tls-0.0.7'
+expect_failure 'exactly one Companion-Core' v1-tls-0.0.7
+
+printf 'release notes generator tests passed.\n'


### PR DESCRIPTION
## Outcome and root cause

Panel release notes previously inferred the companion Core version from release timestamps and synthesized placeholder-tag summaries from the first three PR titles. That made the first side of a Core/Panel release pair order-dependent and allowed PR ordering to masquerade as the final release outcome.

This PR makes the annotated tag the authoritative release contract.

## Changes

- Require an annotated `v*-tls-*` tag with a meaningful subject.
- Require exactly one `Companion-Core: v*-tls-*` line in the tag body.
- Remove timestamp-based companion inference, PR-order summary synthesis, duplicate first-parent highlights, and cross-product `--product` selection.
- Preserve an existing Release title/body on manual dispatch unless `rewrite_release_notes` is explicitly enabled; continue uploading `management.html` with `--clobber`.
- Add deterministic Git fixtures for TLS previous-tag selection, lightweight/placeholder tags, missing/invalid/duplicate companion metadata, and GitHub generated-notes fallback.
- Update README/runbook guidance and run the fixture in Panel contract CI.

## Impact and compatibility

- `dist/index.html` is still renamed and published as exactly `management.html`.
- Node 20, `npm ci`, `VERSION`, tag validation, single-file build, and Core download repository remain unchanged.
- Existing Releases and tags are not modified by this PR.
- No new tag or Release is created.
- A real future tag-to-Release run remains the end-to-end release-context verification.

## Validation

- `scripts/generate-lts-release-notes_test.sh`
- `shellcheck scripts/generate-lts-release-notes.sh scripts/generate-lts-release-notes_test.sh`
- `actionlint .github/workflows/release.yml .github/workflows/lts-panel-contract.yml`
- `npm run validate:lts`
- `git diff --check`

Not run: live workflow dispatch or Release publication, because validation must not rewrite a public Release or upload an asset.

## Review focus

- Annotated-tag and `Companion-Core` validation in `scripts/generate-lts-release-notes.sh`.
- Existing-Release preservation and `management.html` upload behavior in `.github/workflows/release.yml`.
- Fixture coverage in `scripts/generate-lts-release-notes_test.sh`.