### PR TITLE
feat(providers): port upstream temporarily-hidden sponsor brands mechanism

### DIFF
--- a/src/features/providers/sponsorDefinitions.ts
+++ b/src/features/providers/sponsorDefinitions.ts
@@ -116,6 +116,11 @@ const SPONSOR_DEFINITIONS: Record<SponsorProviderBrand, SponsorProviderDefinitio
 export const isMultiProtocolSponsorBrand = (brand: ProviderBrand): brand is SponsorProviderBrand =>
   brand === 'code0' || brand === 'fennoAI' || brand === 'qiniuCloud' || brand === 'infistar';
 
+export const TEMPORARILY_HIDDEN_SPONSOR_BRANDS: ReadonlySet<SponsorProviderBrand> = new Set([]);
+
+export const isTemporarilyHiddenSponsorBrand = (brand: ProviderBrand): boolean =>
+  TEMPORARILY_HIDDEN_SPONSOR_BRANDS.has(brand as SponsorProviderBrand);
+
 export type SponsorAggregationConflict = 'multiple-configs' | 'multiple-openai-keys';
 
 export const getSponsorAggregationConflict = (

--- a/src/features/providers/useProviderWorkbench.ts
+++ b/src/features/providers/useProviderWorkbench.ts
@@ -59,6 +59,8 @@ import {
 import {
   getSponsorOpenAIDeleteIndices,
   getSponsorProviderDefinition,
+  isTemporarilyHiddenSponsorBrand,
+  TEMPORARILY_HIDDEN_SPONSOR_BRANDS,
   type SponsorProtocolUrls,
 } from './sponsorDefinitions';
 import { runSponsorMutationWithRecovery } from './sponsorMutationRecovery';
@@ -419,6 +421,9 @@ export function useProviderWorkbench(): UseProviderWorkbenchResult {
 
   const snapshot = useMemo<ProviderSnapshot | null>(() => {
     if (!config) return null;
+    // 临时隐藏的赞助商：不排除其协议配置，让各协议分组接管显示（见 sponsorDefinitions.ts）
+    const fennoAIHidden = TEMPORARILY_HIDDEN_SPONSOR_BRANDS.has('fennoAI');
+    const qiniuCloudHidden = TEMPORARILY_HIDDEN_SPONSOR_BRANDS.has('qiniuCloud');
     const groups: ProviderGroup[] = PROVIDER_BRAND_ORDER.map((brand) => {
       let resources: ProviderResource[] = [];
       switch (brand) {
@@ -427,7 +432,7 @@ export function useProviderWorkbench(): UseProviderWorkbenchResult {
             (out, item, index) => {
               if (
                 !isCode0GeminiProvider(item) &&
-                !isQiniuCloudGeminiProvider(item) &&
+                (qiniuCloudHidden || !isQiniuCloudGeminiProvider(item)) &&
                 !isInfistarGeminiProvider(item)
               ) {
                 out.push(geminiToResource(item, index));
@@ -441,8 +446,8 @@ export function useProviderWorkbench(): UseProviderWorkbenchResult {
           resources = (config.codexApiKeys ?? []).reduce<ProviderResource[]>((out, item, index) => {
             if (
               !isCode0CodexProvider(item) &&
-              !isFennoAICodexProvider(item) &&
-              !isQiniuCloudCodexProvider(item) &&
+              (fennoAIHidden || !isFennoAICodexProvider(item)) &&
+              (qiniuCloudHidden || !isQiniuCloudCodexProvider(item)) &&
               !isInfistarCodexProvider(item)
             ) {
               out.push(codexToResource(item, index));
@@ -458,8 +463,8 @@ export function useProviderWorkbench(): UseProviderWorkbenchResult {
             (out, item, index) => {
               if (
                 !isCode0ClaudeProvider(item) &&
-                !isFennoAIClaudeProvider(item) &&
-                !isQiniuCloudClaudeProvider(item) &&
+                (fennoAIHidden || !isFennoAIClaudeProvider(item)) &&
+                (qiniuCloudHidden || !isQiniuCloudClaudeProvider(item)) &&
                 !isInfistarClaudeProvider(item) &&
                 !isClaudeApiProvider(item)
               ) {
@@ -489,7 +494,7 @@ export function useProviderWorkbench(): UseProviderWorkbenchResult {
             (out, item, index) => {
               if (
                 !isCode0OpenAIProvider(item) &&
-                !isQiniuCloudOpenAIProvider(item) &&
+                (qiniuCloudHidden || !isQiniuCloudOpenAIProvider(item)) &&
                 !isInfistarOpenAIProvider(item)
               ) {
                 out.push(openaiToResource(item, index));
@@ -524,7 +529,8 @@ export function useProviderWorkbench(): UseProviderWorkbenchResult {
         id: brand,
         resources,
       };
-    }).filter((group) => group.resources.length > 0 || !CONFIG_DETECTED_BRANDS.has(group.id));
+    }).filter((group) => group.resources.length > 0 || !CONFIG_DETECTED_BRANDS.has(group.id))
+      .filter((group) => !isTemporarilyHiddenSponsorBrand(group.id));
     return {
       fetchedAt,
       groups,


### PR DESCRIPTION
## Summary

Selective port of upstream `router-for-me/Cli-Proxy-API-Management-Center` commits `73db424` + `6586f88` (net effect after the follow-up clear).

### What upstream did (last 7 days)
Upstream shipped 4 commits, all sponsor-related:
1. `3d922bf` / `c6c8e3b`: add BestProxy sponsor link under the proxy URL field in visual config (new sponsors.ts, Input labelExtra/topExtra props, IconHeart, wide field anchor).
2. `73db424`: introduce TEMPORARILY_HIDDEN_SPONSOR_BRANDS to hide FennoAI/QiniuCloud brand groups in provider workbench (entries fall back to protocol groups).
3. `6586f88`: clear the hidden list back to empty — net effect is the mechanism itself with no behavioral change.

### LTS intake decision
- **Rejected**: BestProxy sponsor link (`3d922bf`, `c6c8e3b`) and the 38b6ac6 Claudeapi.com rename context. Sponsor advertising surface is not part of the LTS protected/maintained feature set; our visual config editor has a different structure (no sharedFields/FieldPrimitives), so this is a different-solution/different-surface case.
- **Ported**: the temporarily-hidden sponsor brands mechanism. Our workbench shares the same structure as upstream (fennoAI/qiniuCloud brands, PROVIDER_BRAND_ORDER grouping). Porting keeps future upstream sponsor-brand toggles diffable against our tree and gives us a zero-risk operational switch to hide a sponsor brand without deleting its descriptor/adapter code.
- Behavior is unchanged: the set is empty; all protocol-group exclusion predicates short-circuit identically.

### Files changed
- src/features/providers/sponsorDefinitions.ts: add empty TEMPORARILY_HIDDEN_SPONSOR_BRANDS set + isTemporarilyHiddenSponsorBrand guard
- src/features/providers/useProviderWorkbench.ts: wire hidden flags into snapshot grouping predicates and filter hidden brand groups

## Validation
- npm run test:providers — pass (xai 2, integrity 7, recent 2)
- npm run type-check — pass
- npm run lint — pass
- npm run build — pass (single-file dist generated)
- npm run check:lts — pass

No protected usage/statistics surface touched; no locale or contract registry changes required.