### PR TITLE
feat(ui): 统一凭据与额度卡片的 Provider 图标

### DIFF
--- a/src/components/quota/QuotaCard.tsx
+++ b/src/components/quota/QuotaCard.tsx
@@ -7,12 +7,8 @@ import type { ReactElement, ReactNode } from 'react';
 import type { TFunction } from 'i18next';
 import { Button } from '@/components/ui/Button';
 import { IconRefreshCw } from '@/components/ui/icons';
-import {
-  getAuthFileIcon,
-  getThemeSurfaceIconBackground,
-  getTypeLabel,
-  isThemeSurfaceIconProvider,
-} from '@/features/authFiles/constants';
+import { getTypeLabel } from '@/features/authFiles/constants';
+import { ProviderIcon } from '@/features/authFiles/components/ProviderIcon';
 import type { AuthFileItem } from '@/types';
 import styles from '@/pages/QuotaPage.module.scss';
 
@@ -98,7 +94,6 @@ export function QuotaCard<TState extends QuotaStatusState>({
 
   const displayType = item.type || item.provider || defaultType;
   const typeLabel = getTypeLabel(t, displayType);
-  const iconSrc = getAuthFileIcon(displayType);
 
   const quotaStatus = quota?.status ?? 'idle';
   const quotaLoading = quotaStatus === 'loading';
@@ -114,23 +109,12 @@ export function QuotaCard<TState extends QuotaStatusState>({
   return (
     <div className={`${styles.fileCard} ${cardClassName}`} role="article">
       <div className={styles.cardHeader}>
-        <span
+        <ProviderIcon
+          provider={displayType}
+          size="card"
           className={styles.providerIconWrap}
           title={typeLabel}
-          style={
-            isThemeSurfaceIconProvider(displayType)
-              ? { background: getThemeSurfaceIconBackground() }
-              : undefined
-          }
-        >
-          {iconSrc ? (
-            <img src={iconSrc} alt="" className={styles.providerIcon} />
-          ) : (
-            <span className={styles.providerIconFallback}>
-              {typeLabel.slice(0, 1).toUpperCase()}
-            </span>
-          )}
-        </span>
+        />
         <span className={styles.cardIdentity}>
           <span className={styles.fileName} title={item.name}>
             {item.name}

--- a/src/features/authFiles/components/AuthFileCard.tsx
+++ b/src/features/authFiles/components/AuthFileCard.tsx
@@ -29,20 +29,18 @@ import { readCredentialWeight } from '@/utils/credentialWeight';
 import {
   QUOTA_PROVIDER_TYPES,
   formatModified,
-  getAuthFileIcon,
   getAuthFileStatusMessage,
-  getThemeSurfaceIconBackground,
   getTypeColor,
   getTypeLabel,
   hasAuthFileStatusWarning,
   isRuntimeOnlyAuthFile,
-  isThemeSurfaceIconProvider,
   normalizeProviderKey,
   parsePriorityValue,
   type QuotaProviderType,
 } from '@/features/authFiles/constants';
 import type { AuthFileStatusBarData } from '@/features/authFiles/hooks/useAuthFilesStatusBarCache';
 import { AuthFileQuotaSection } from '@/features/authFiles/components/AuthFileQuotaSection';
+import { ProviderIcon } from '@/features/authFiles/components/ProviderIcon';
 import styles from '@/pages/AuthFilesPage.module.scss';
 
 export type AuthFileCardProps = {
@@ -102,8 +100,6 @@ export function AuthFileCard(props: AuthFileCardProps) {
   const showModelsButton = !isRuntimeOnly || isAistudio;
   const typeColor = getTypeColor(providerKey);
   const typeLabel = getTypeLabel(t, providerKey);
-  const providerIcon = getAuthFileIcon(providerKey);
-  const useThemeSurfaceIcon = isThemeSurfaceIconProvider(providerKey);
 
   const quotaType =
     quotaFilterType && resolveQuotaType(file) === quotaFilterType ? quotaFilterType : null;
@@ -171,29 +167,11 @@ export function AuthFileCard(props: AuthFileCardProps) {
                 title={selected ? t('auth_files.batch_deselect') : t('auth_files.batch_select_all')}
               />
             )}
-            <div
+            <ProviderIcon
+              provider={providerKey}
+              size={compact ? 'compact' : 'card'}
               className={styles.providerAvatar}
-              style={
-                useThemeSurfaceIcon
-                  ? {
-                      backgroundColor: getThemeSurfaceIconBackground(),
-                      color: typeColor.text,
-                    }
-                  : {
-                      backgroundColor: typeColor.bg,
-                      color: typeColor.text,
-                      ...(typeColor.border ? { border: typeColor.border } : {}),
-                    }
-              }
-            >
-              {providerIcon ? (
-                <img src={providerIcon} alt="" className={styles.providerAvatarImage} />
-              ) : (
-                <span className={styles.providerAvatarFallback}>
-                  {typeLabel.slice(0, 1).toUpperCase()}
-                </span>
-              )}
-            </div>
+            />
             <div className={styles.cardHeaderContent}>
               <div className={styles.cardBadgeRow}>
                 <span

--- a/src/features/authFiles/components/ProviderIcon.module.scss
+++ b/src/features/authFiles/components/ProviderIcon.module.scss
@@ -1,0 +1,79 @@
+.wrap {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  flex-shrink: 0;
+  box-sizing: border-box;
+  overflow: hidden;
+}
+
+.card {
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+}
+
+.compact {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+}
+
+.nav {
+  width: 24px;
+  height: 24px;
+  border-radius: 6px;
+}
+
+.neutral {
+  background: color-mix(in srgb, var(--bg-tertiary) 72%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border-color) 60%, transparent);
+  color: var(--text-secondary);
+}
+
+.brand {
+  border: 1px solid transparent;
+}
+
+.theme {
+  border: 1px solid transparent;
+  color: #fff;
+}
+
+.image {
+  object-fit: contain;
+  display: block;
+}
+
+.card .image {
+  width: 22px;
+  height: 22px;
+}
+
+.compact .image {
+  width: 18px;
+  height: 18px;
+}
+
+.nav .image {
+  width: 16px;
+  height: 16px;
+}
+
+.fallback {
+  font-weight: 700;
+  line-height: 1;
+}
+
+.card .fallback {
+  font-size: 18px;
+}
+
+.compact .fallback {
+  font-size: 14px;
+}
+
+.nav .fallback {
+  font-size: 11px;
+}

--- a/src/features/authFiles/components/ProviderIcon.tsx
+++ b/src/features/authFiles/components/ProviderIcon.tsx
@@ -1,0 +1,62 @@
+import { useTranslation } from 'react-i18next';
+import {
+  getAuthFileIcon,
+  getThemeSurfaceIconBackground,
+  getTypeColor,
+  getTypeLabel,
+  isThemeSurfaceIconProvider,
+} from '@/features/authFiles/constants';
+import styles from './ProviderIcon.module.scss';
+
+export type ProviderIconSize = 'card' | 'compact' | 'nav';
+export type ProviderIconSurface = 'neutral' | 'brand' | 'theme';
+
+export type ProviderIconProps = {
+  provider: string;
+  size?: ProviderIconSize;
+  surface?: ProviderIconSurface;
+  className?: string;
+  title?: string;
+};
+
+const resolveSurface = (provider: string, surface?: ProviderIconSurface): ProviderIconSurface => {
+  if (surface) return surface;
+  return isThemeSurfaceIconProvider(provider) ? 'theme' : 'neutral';
+};
+
+export function ProviderIcon({
+  provider,
+  size = 'card',
+  surface,
+  className,
+  title,
+}: ProviderIconProps) {
+  const { t } = useTranslation();
+  const resolvedSurface = resolveSurface(provider, surface);
+  const typeLabel = getTypeLabel(t, provider);
+  const iconSrc = getAuthFileIcon(provider);
+  const typeColor = getTypeColor(provider);
+  const wrapClassName = [styles.wrap, styles[size], styles[resolvedSurface], className]
+    .filter(Boolean)
+    .join(' ');
+  const wrapStyle =
+    resolvedSurface === 'theme'
+      ? { backgroundColor: getThemeSurfaceIconBackground() }
+      : resolvedSurface === 'brand'
+        ? {
+            backgroundColor: typeColor.bg,
+            color: typeColor.text,
+            ...(typeColor.border ? { border: typeColor.border } : {}),
+          }
+        : undefined;
+
+  return (
+    <span className={wrapClassName} style={wrapStyle} title={title} aria-hidden="true">
+      {iconSrc ? (
+        <img src={iconSrc} alt="" className={styles.image} />
+      ) : (
+        <span className={styles.fallback}>{typeLabel.slice(0, 1).toUpperCase()}</span>
+      )}
+    </span>
+  );
+}

--- a/src/features/authFiles/components/ProviderTabs.module.scss
+++ b/src/features/authFiles/components/ProviderTabs.module.scss
@@ -72,7 +72,8 @@
 
 .tabGlyph {
   flex-shrink: 0;
-  color: var(--text-tertiary);
+  display: block;
+  color: color-mix(in srgb, var(--primary-color) 70%, var(--text-primary));
 
   .tabActive & {
     color: var(--text-primary);
@@ -81,25 +82,17 @@
 
 .tabIconWrap {
   flex-shrink: 0;
-  display: flex;
+}
+
+.tabAllIconWrap {
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 18px;
-  height: 18px;
-  border-radius: 5px;
-}
-
-.tabIcon {
-  width: 15px;
-  height: 15px;
-  object-fit: contain;
-  display: block;
-}
-
-.tabIconFallback {
-  font-size: 10px;
-  font-weight: 700;
-  color: var(--text-secondary);
+  width: 24px;
+  height: 24px;
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--bg-tertiary) 72%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border-color) 60%, transparent);
 }
 
 .tabLabel {
@@ -107,15 +100,20 @@
 }
 
 .tabCount {
-  font-family: $font-mono;
-  font-size: 10.5px;
-  font-weight: 650;
-  font-variant-numeric: tabular-nums;
-  line-height: 1.6;
-  color: var(--text-tertiary);
+  display: inline-grid;
+  place-items: center;
+  min-width: 20px;
+  height: 20px;
   padding: 0 6px;
-  border-radius: $radius-full;
+  border-radius: 6px;
+  font-family: $font-mono;
+  font-size: 11px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+  color: var(--text-tertiary);
   background: color-mix(in srgb, var(--text-primary) 6%, transparent);
+  text-align: center;
 
   .tabActive & {
     color: var(--text-primary);

--- a/src/features/authFiles/components/ProviderTabs.tsx
+++ b/src/features/authFiles/components/ProviderTabs.tsx
@@ -1,11 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { IconFilterAll } from '@/components/ui/icons';
-import {
-  getAuthFileIcon,
-  getThemeSurfaceIconBackground,
-  getTypeLabel,
-  isThemeSurfaceIconProvider,
-} from '@/features/authFiles/constants';
+import { getTypeLabel } from '@/features/authFiles/constants';
+import { ProviderIcon } from '@/features/authFiles/components/ProviderIcon';
 import styles from './ProviderTabs.module.scss';
 
 export type ProviderTabsProps = {
@@ -24,7 +20,6 @@ export function ProviderTabs({ types, counts, active, onChange }: ProviderTabsPr
       {types.map((type) => {
         const isActive = active === type;
         const label = type === 'all' ? t('auth_files.filter_all') : getTypeLabel(t, type);
-        const iconSrc = type === 'all' ? null : getAuthFileIcon(type);
 
         return (
           <button
@@ -35,24 +30,11 @@ export function ProviderTabs({ types, counts, active, onChange }: ProviderTabsPr
             onClick={() => onChange(type)}
           >
             {type === 'all' ? (
-              <IconFilterAll className={styles.tabGlyph} size={15} />
-            ) : (
-              <span
-                className={styles.tabIconWrap}
-                style={
-                  isThemeSurfaceIconProvider(type)
-                    ? { background: getThemeSurfaceIconBackground() }
-                    : undefined
-                }
-              >
-                {iconSrc ? (
-                  <img src={iconSrc} alt="" className={styles.tabIcon} />
-                ) : (
-                  <span className={styles.tabIconFallback}>
-                    {label.slice(0, 1).toUpperCase()}
-                  </span>
-                )}
+              <span className={`${styles.tabIconWrap} ${styles.tabAllIconWrap}`}>
+                <IconFilterAll className={styles.tabGlyph} size={16} />
               </span>
+            ) : (
+              <ProviderIcon provider={type} size="nav" className={styles.tabIconWrap} />
             )}
             <span className={styles.tabLabel}>{label}</span>
             <span className={styles.tabCount}>{counts[type] ?? 0}</span>

--- a/src/pages/AuthFilesPage.module.scss
+++ b/src/pages/AuthFilesPage.module.scss
@@ -101,14 +101,14 @@
 }
 
 .filterAllIconWrap {
-  position: relative;
-  border-color: color-mix(in srgb, var(--primary-color) 20%, var(--border-color));
-  background: linear-gradient(
-    145deg,
-    color-mix(in srgb, var(--bg-secondary) 94%, var(--primary-color) 8%),
-    color-mix(in srgb, var(--bg-primary) 92%, var(--primary-color) 5%)
-  );
-  box-shadow: 0 10px 22px -18px color-mix(in srgb, var(--primary-color) 50%, transparent);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--bg-tertiary) 72%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border-color) 60%, transparent);
 }
 
 .filterAllIcon {
@@ -162,10 +162,6 @@
   border-color: color-mix(in srgb, var(--filter-color) 50%, var(--border-color));
   background: color-mix(in srgb, var(--filter-surface) 22%, var(--bg-secondary));
   color: var(--text-primary);
-
-  .filterTagIconWrap {
-    border-color: color-mix(in srgb, var(--filter-color) 40%, transparent);
-  }
 }
 
 .filterTagLabel {
@@ -176,29 +172,7 @@
 }
 
 .filterTagIconWrap {
-  width: 24px;
-  height: 24px;
   flex: 0 0 auto;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 6px;
-  border: 1px solid color-mix(in srgb, var(--border-color) 50%, transparent);
-  background: color-mix(in srgb, var(--bg-tertiary) 60%, transparent);
-}
-
-.filterTagIcon {
-  width: 16px;
-  height: 16px;
-  flex: 0 0 auto;
-  object-fit: contain;
-}
-
-.filterTagIconFallback {
-  color: var(--filter-color);
-  font-size: 14px;
-  font-weight: 700;
-  line-height: 1;
 }
 
 .filterTagText {
@@ -797,7 +771,6 @@
   background-color: color-mix(in srgb, var(--bg-primary) 78%, var(--bg-secondary));
   border-color: color-mix(in srgb, var(--border-color) 62%, transparent);
 
-  .providerAvatar,
   .cardHeaderContent,
   .cardMeta,
   .healthStatusMessage,
@@ -831,21 +804,6 @@
 
   .cardSelection {
     margin-top: 6px;
-  }
-
-  .providerAvatar {
-    width: 34px;
-    height: 34px;
-    border-radius: 8px;
-  }
-
-  .providerAvatarImage {
-    width: 16px;
-    height: 16px;
-  }
-
-  .providerAvatarFallback {
-    font-size: 14px;
   }
 
   .cardHeaderContent {
@@ -942,26 +900,7 @@
 }
 
 .providerAvatar {
-  width: 40px;
-  height: 40px;
   flex: 0 0 auto;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 10px;
-  border: 1px solid color-mix(in srgb, var(--border-color) 60%, transparent);
-}
-
-.providerAvatarImage {
-  width: 22px;
-  height: 22px;
-  object-fit: contain;
-}
-
-.providerAvatarFallback {
-  font-size: 18px;
-  font-weight: 700;
-  line-height: 1;
 }
 
 .cardHeaderContent {
@@ -1030,7 +969,7 @@
 
 .fileName {
   font-size: 14px;
-  font-weight: 800;
+  font-weight: 700;
   color: var(--text-primary);
   word-break: break-all;
   line-height: 1.4;

--- a/src/pages/AuthFilesPage.tsx
+++ b/src/pages/AuthFilesPage.tsx
@@ -30,18 +30,16 @@ import {
   MIN_CARD_PAGE_SIZE,
   QUOTA_PROVIDER_TYPES,
   clampCardPageSize,
-  getAuthFileIcon,
-  getThemeSurfaceIconBackground,
   getTypeColor,
   getTypeLabel,
   isProblemAuthFile,
   isRuntimeOnlyAuthFile,
-  isThemeSurfaceIconProvider,
   normalizeProviderKey,
   parsePriorityValue,
   type QuotaProviderType,
 } from '@/features/authFiles/constants';
 import { AuthFileCard } from '@/features/authFiles/components/AuthFileCard';
+import { ProviderIcon } from '@/features/authFiles/components/ProviderIcon';
 import { AuthFileModelsModal } from '@/features/authFiles/components/AuthFileModelsModal';
 import { AuthFilesPrefixProxyEditorModal } from '@/features/authFiles/components/AuthFilesPrefixProxyEditorModal';
 import { OAuthExcludedCard } from '@/features/authFiles/components/OAuthExcludedCard';
@@ -626,7 +624,6 @@ export function AuthFilesPage() {
       <div className={styles.filterTags}>
         {existingTypes.map((type) => {
           const isActive = normalizedFilter === type;
-          const iconSrc = getAuthFileIcon(type);
           const color =
             type === 'all'
               ? { bg: 'var(--bg-tertiary)', text: 'var(--text-primary)' }
@@ -650,25 +647,7 @@ export function AuthFilesPage() {
                     <IconFilterAll className={styles.filterAllIcon} size={16} />
                   </span>
                 ) : (
-                  <span
-                    className={styles.filterTagIconWrap}
-                    style={
-                      isThemeSurfaceIconProvider(type)
-                        ? {
-                            background: getThemeSurfaceIconBackground(),
-                            borderColor: 'transparent',
-                          }
-                        : undefined
-                    }
-                  >
-                    {iconSrc ? (
-                      <img src={iconSrc} alt="" className={styles.filterTagIcon} />
-                    ) : (
-                      <span className={styles.filterTagIconFallback}>
-                        {getTypeLabel(t, type).slice(0, 1).toUpperCase()}
-                      </span>
-                    )}
-                  </span>
+                  <ProviderIcon provider={type} size="nav" className={styles.filterTagIconWrap} />
                 )}
                 <span className={styles.filterTagText}>{getTypeLabel(t, type)}</span>
               </span>

--- a/src/pages/QuotaPage.module.scss
+++ b/src/pages/QuotaPage.module.scss
@@ -295,27 +295,27 @@
 
 // 卡片渐变背景 — 基于 TYPE_COLORS.bg 转 rgba
 .claudeCard {
-  background-image: linear-gradient(180deg, rgba(251, 236, 228, 0.18), rgba(251, 236, 228, 0));
+  background-image: linear-gradient(180deg, rgba(251, 236, 228, 0.08), transparent);
 }
 
 .antigravityCard {
-  background-image: linear-gradient(180deg, rgba(224, 247, 250, 0.12), rgba(224, 247, 250, 0));
+  background-image: linear-gradient(180deg, rgba(224, 247, 250, 0.08), transparent);
 }
 
 .codexCard {
-  background-image: linear-gradient(180deg, rgba(234, 231, 255, 0.18), rgba(234, 231, 255, 0));
+  background-image: linear-gradient(180deg, rgba(234, 231, 255, 0.08), transparent);
 }
 
 .geminiCliCard {
-  background-image: linear-gradient(180deg, rgba(224, 232, 255, 0.2), rgba(224, 232, 255, 0));
+  background-image: linear-gradient(180deg, rgba(224, 232, 255, 0.08), transparent);
 }
 
 .kimiCard {
-  background-image: linear-gradient(180deg, rgba(220, 232, 255, 0.2), rgba(220, 232, 255, 0));
+  background-image: linear-gradient(180deg, rgba(220, 232, 255, 0.08), transparent);
 }
 
 .xaiCard {
-  background-image: linear-gradient(180deg, rgba(243, 244, 246, 0.22), rgba(243, 244, 246, 0));
+  background-image: linear-gradient(180deg, rgba(243, 244, 246, 0.08), transparent);
 }
 
 .quotaSection {
@@ -749,8 +749,8 @@
 
 .fileCard {
   background-color: var(--bg-primary);
-  border: 1px solid color-mix(in srgb, var(--border-color) 92%, transparent);
-  border-radius: 14px;
+  border: 1px solid color-mix(in srgb, var(--border-color) 70%, transparent);
+  border-radius: 12px;
   padding: 16px;
   display: flex;
   flex-direction: column;
@@ -775,34 +775,12 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  min-height: 34px;
+  min-height: 40px;
   min-width: 0;
 }
 
 .providerIconWrap {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 30px;
-  height: 30px;
-  border-radius: 9px;
-  background: color-mix(in srgb, var(--bg-tertiary) 88%, transparent);
-  border: 1px solid color-mix(in srgb, var(--border-color) 82%, transparent);
   flex-shrink: 0;
-}
-
-.providerIcon {
-  width: 20px;
-  height: 20px;
-  object-fit: contain;
-  display: block;
-}
-
-.providerIconFallback {
-  font-size: 11px;
-  line-height: 1;
-  font-weight: 750;
-  color: var(--text-secondary);
 }
 
 .cardIdentity {
@@ -814,17 +792,18 @@
 
 .fileName {
   font-family: $font-mono;
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 650;
   color: var(--text-primary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   line-height: 1.35;
+  letter-spacing: -0.01em;
 }
 
 .providerName {
-  font-size: 11px;
+  font-size: 12px;
   line-height: 1.25;
   color: var(--text-tertiary);
 }


### PR DESCRIPTION
## 结果与边界

统一 Auth Files 与 Quota 卡片的 provider identity icon，使同一 credential/provider 在筛选、卡片与 quota 页面保持相同图标、尺寸和 surface 语义，同时保留两个页面各自的任务布局。

本 PR 只包含 UI component/style 整理，不改 credential、quota、Management API、缓存或持久化语义；尚未发布或部署。

## 主要变更

- 新增共享 `ProviderIcon`，统一 `card`、`compact`、`nav` 尺寸及 neutral/brand/theme surface。
- Auth file cards、provider tabs、Auth Files filter 与 Quota cards 复用同一图标组件。
- 保持现有 provider label、fallback glyph 和 theme surface 判定。
- 收敛重复 SCSS，并微调 quota card 的 header、字体和背景层级。

## 兼容性

- 不改变 API request、auth-file 内容、provider key、quota 数据或用户存储。
- 未新增依赖。

## 验证

- `npm run validate:lts`：通过。
- `npm run smoke:lts`：通过。
- `git show --check 71d5508c794afd97e67ec87c87d4eab44a714c61`：通过。

## Review focus

- `ProviderIcon` 的 accessibility/fallback 行为。
- Auth Files 与 Quota 页面在 theme surface 下的尺寸和边框一致性。
