### PR TITLE
fix(release): 从精确 tag 构建 management.html

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,12 +29,35 @@ jobs:
       contents: write
 
     steps:
-      - name: Checkout code
+      - name: Checkout release source
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ env.RELEASE_TAG }}
           fetch-depth: 0
           fetch-tags: true
+
+      - name: Checkout current release tooling
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          path: _release_tools
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Verify release source
+        run: |
+          set -euo pipefail
+          if [[ "${RELEASE_TAG}" != v*-lts-* ]]; then
+            echo "Only Panel LTS release tags matching v*-lts-* are supported." >&2
+            exit 1
+          fi
+          tag_commit="$(git rev-parse "${RELEASE_TAG}^{commit}")"
+          head_commit="$(git rev-parse HEAD)"
+          if [[ "$head_commit" != "$tag_commit" ]]; then
+            echo "Release source mismatch: HEAD=${head_commit}, ${RELEASE_TAG}=${tag_commit}." >&2
+            exit 1
+          fi
+          echo "Verified ${RELEASE_TAG} at ${tag_commit}."
 
       - name: Setup Node.js
         uses: actions/setup-node@v7
@@ -48,7 +71,7 @@ jobs:
       - name: Build all-in-one HTML
         run: npm run build
         env:
-          VERSION: ${{ github.event.inputs.release_tag || github.ref_name }}
+          VERSION: ${{ env.RELEASE_TAG }}
 
       - name: Prepare release assets
         run: |
@@ -79,10 +102,10 @@ jobs:
             exit 0
           fi
 
-          bash scripts/generate-lts-release-notes.sh \
+          bash _release_tools/scripts/generate-lts-release-notes.sh \
             --tag "${RELEASE_TAG}" \
-            --notes-file release-notes.md \
-            --title-file release-title.txt
+            --notes-file "$GITHUB_WORKSPACE/release-notes.md" \
+            --title-file "$GITHUB_WORKSPACE/release-title.txt"
           echo "RELEASE_TITLE=$(tr -d '\n' < release-title.txt)" >> "$GITHUB_ENV"
           echo "RELEASE_NOTES_READY=true" >> "$GITHUB_ENV"
 
@@ -104,6 +127,13 @@ jobs:
             gh release create "$RELEASE_TAG" dist/management.html \
               --title "$RELEASE_TITLE" \
               --notes-file release-notes.md
+          fi
+
+          published_assets="$(gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name')"
+          if [[ "$published_assets" != "management.html" ]]; then
+            echo "Published release assets must contain only management.html; got:" >&2
+            printf '%s\n' "$published_assets" >&2
+            exit 1
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/lts/panel-protected-deltas.yaml
+++ b/docs/lts/panel-protected-deltas.yaml
@@ -38,6 +38,7 @@ protected_deltas:
       - release asset named management.html
       - npm/package-lock based build
       - v*-lts-* release tag guard
+      - release source resolves to the exact requested tag commit
   - id: local-downstream-customizations
     reason: This repository contains downstream panel work that is not present upstream.
     must_keep:

--- a/scripts/check-lts-panel-contract.sh
+++ b/scripts/check-lts-panel-contract.sh
@@ -513,9 +513,14 @@ require_file_contains src/services/api/index.ts "export * from './usage'"
 require_file_contains src/services/api/index.ts "export * from './ampcode'"
 require_file_contains .github/workflows/release.yml "management.html"
 require_file_contains .github/workflows/release.yml "v*-lts-*"
+require_file_contains .github/workflows/release.yml 'ref: ${{ env.RELEASE_TAG }}'
+require_file_contains .github/workflows/release.yml "Checkout current release tooling"
+require_file_contains .github/workflows/release.yml "Release source mismatch"
+require_file_not_contains .github/workflows/release.yml 'ref: ${{ github.ref }}'
 require_file_contains docs/lts/panel-protected-deltas.yaml "full-usage-statistics-ui"
 require_file_contains docs/lts/panel-protected-deltas.yaml "cpa-core-lts-management-api-compatibility"
 require_file_contains docs/lts/panel-protected-deltas.yaml "panel-release-contract"
+require_file_contains docs/lts/panel-protected-deltas.yaml "release source resolves to the exact requested tag commit"
 require_file_contains docs/lts/sync-runbook.md "protected selective-port"
 require_file_contains docs/lts/panel-feature-contracts.yaml "npm run test:usage-cache"
 


### PR DESCRIPTION
## 结论与问题

修复 Panel 的 `workflow_dispatch.release_tag` 只控制版本字符串、但实际从触发分支（通常是 `main`）构建 `management.html` 的问题。此前历史 Release 可能只是替换了版本字符串，产品代码仍来自同一个最新 `main`。

## 主要变更

- 产品源码 checkout 精确 `RELEASE_TAG`，并校验 `HEAD == <tag>^{commit}`。
- 当前 release-note generator 独立 checkout 到 `_release_tools`，允许修复旧 tag 而不污染历史产品源码。
- `VERSION` 统一取 `RELEASE_TAG`。
- 发布后回读 Release，要求资产集合严格为单个 `management.html`。
- 将 exact requested tag source 加入 Panel release protected contract 和 executable guard。

## 兼容性与边界

- 保留 npm/lockfile 构建、`v*-lts-*` guard 和精确的 `management.html` 资产名。
- 本 PR 不创建或覆盖 GitHub Release；历史资产需在合并后通过修复后的 workflow 逐 tag 重建并回读。

## Validation

- `actionlint .github/workflows/release.yml`
- `scripts/generate-lts-release-notes_test.sh`
- `npm run validate:lts`（全部配置的 Node tests、contract、type-check、lint、single-file build）
- `git diff --check`
- 从最老 `v1-lts-0.0.1` tag tree 执行 `npm ci` 与 `npm run build`，生成的 HTML 包含正确 tag 版本；tag target 为 `21303f0d...`

## Review focus

1. 历史 tag 产品源码与当前 release tooling 的 checkout 边界。
2. `management.html` 发布后的唯一资产回读。
