### PR TITLE
fix(release): authenticate historical Release detection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,8 @@ jobs:
           ls -lh management.html
 
       - name: Generate release notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           if [[ "${RELEASE_TAG}" != v*-lts-* ]]; then


### PR DESCRIPTION
## 结果

修复手工历史 Release 重建时错误地把已有 Release 判断为不存在，导致发布步骤尝试重复创建同名 Release 并失败。

## 根因与改动

`Generate release notes` 步骤调用 `gh release view`，但该步骤没有向 GitHub CLI 提供 `GITHUB_TOKEN`。认证失败被现有的存在性判断当成“Release 不存在”。本变更只为该步骤注入工作流自带的 `GITHUB_TOKEN`；历史 Release 的标题和说明仍按 `rewrite_release_notes=false` 保留，资产仍只覆盖 `management.html`。

## 验证

- `actionlint .github/workflows/release.yml`
- `npm run check:lts`
- `git diff --check`

线上 canary `v1-lts-0.0.1` 已证明精确 tag checkout、依赖安装和 2.42 MB 单文件构建成功；此前只在已有 Release 检测后的发布步骤失败。合并后将重新运行该 canary，再继续批量历史重建。