### PR TITLE
fix(theme): darken solid primary button background for aurora themes

### DIFF
--- a/src/styles/components.scss
+++ b/src/styles/components.scss
@@ -16,13 +16,13 @@
   color: var(--text-primary);
 
   &.btn-primary {
-    background-color: var(--primary-color);
+    background-color: var(--primary-button-bg);
     color: var(--primary-contrast, #fff);
-    border-color: var(--primary-color);
+    border-color: var(--primary-button-bg);
 
     &:hover {
-      background-color: var(--primary-hover);
-      border-color: var(--primary-hover);
+      background-color: var(--primary-button-bg-hover);
+      border-color: var(--primary-button-bg-hover);
     }
   }
 

--- a/src/styles/themes.scss
+++ b/src/styles/themes.scss
@@ -31,6 +31,9 @@
   --primary-hover: #5f5f5f;
   --primary-active: #4d4d4d;
   --primary-contrast: #ffffff;
+  // 实底主操作(按钮):允许比强调色深一档以满足文字对比度
+  --primary-button-bg: var(--primary-color);
+  --primary-button-bg-hover: var(--primary-hover);
 
   --success-color: #10b981;
   --quota-medium-color: #e0aa14;
@@ -121,6 +124,8 @@
   --primary-hover: #9333ea;
   --primary-active: #7e22ce;
   --primary-contrast: #fff5fb;
+  --primary-button-bg: #9333ea;
+  --primary-button-bg-hover: #7e22ce;
 
   --success-color: #4ade80;
   --quota-medium-color: #fbbf24;
@@ -184,6 +189,8 @@
   --primary-hover: #6355e6;
   --primary-active: #5243d6;
   --primary-contrast: #ffffff;
+  --primary-button-bg: #6355e6;
+  --primary-button-bg-hover: #5243d6;
 
   --success-color: #10b981;
   --quota-medium-color: #d97706;


### PR DESCRIPTION
## 背景

三主题色彩审查确认的可读性缺陷之一:两套 Aurora 主题下,通用主按钮 `.btn-primary` 的白字对 `--primary-color` 实底对比度不达普通字号 AA(4.5:1):

| 主题 | 修复前(背景 / 文字) | 对比度 |
|---|---|---:|
| white | `#737373` / `#ffffff` | 4.74:1(达标,不变) |
| aurora-nebula | `#a855f7` / `#fff5fb` | 3.71:1 |
| aurora-dawn | `#7c6cf0` / `#ffffff` | 3.99:1 |

## 方案

- 新增 `--primary-button-bg` / `--primary-button-bg-hover` token:`:root` 默认沿用 `--primary-color` / `--primary-hover`(white 主题行为不变);两套 Aurora 主题下按钮实底下潜一档:
  - aurora-nebula:`#9333ea`(≈5.0:1),hover `#7e22ce`
  - aurora-dawn:`#6355e6`(≈5.3:1),hover `#5243d6`
- `.btn-primary` 底色与边框改用新 token;hover 阶梯同步。
- **有意不全局加深 `--primary-color`**:强调色还大量用于暗底上的强调文字与边框,全局加深会恶化这些场景;本修复只作用于文字承载的实底主按钮。开关、checkbox、进度条等非文字实底保持 3:1 非文字对比度,不在本 PR 范围。

## 范围外(后续项)

- `AuthFilesPage` `providerTagActive` chip(`#fff` 文字直配 `--primary-color`)属同类问题,另行处理。
- Usage 费用五档硬编码文字色、white 主题 tertiary 文字对比度:见审查清单。

## 验证

- `npm run check:lts` ✅
- `npm run type-check` ✅
- `npm run build` ✅
- 对比度数值为按 WCAG 相对亮度公式的计算值;未做登录后整页视觉验收。